### PR TITLE
Account admin can view trainer roster with status

### DIFF
--- a/app/controllers/account/trainers_controller.rb
+++ b/app/controllers/account/trainers_controller.rb
@@ -1,0 +1,5 @@
+class Account::TrainersController < Account::ApplicationController
+  def index
+    @trainers = current_client.users.trainers
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,8 @@ class User < ApplicationRecord
 
   validates :email_address, presence: true, uniqueness: { case_sensitive: false }
   validates :client, presence: true, if: :client_admin?
+
+  enum :status, { active: 0, inactive: 1, pending_password_change: 2 }, default: :active
+
+  scope :trainers, -> { where(client_admin: false, super_admin: false) }
 end

--- a/app/views/account/settings/edit.html.erb
+++ b/app/views/account/settings/edit.html.erb
@@ -1,5 +1,9 @@
 <h1 class="font-bold text-4xl">Account Settings</h1>
 
+<nav class="mt-4 flex gap-4 text-sm">
+  <%= link_to "Trainer Roster", account_trainers_path, class: "text-blue-600 hover:underline" %>
+</nav>
+
 <%= form_with model: @client, url: account_settings_path, method: :patch, class: "mt-8 max-w-lg space-y-6" do |form| %>
   <% if @client.errors.any? %>
     <div class="rounded-md bg-red-50 border border-red-200 p-4">

--- a/app/views/account/trainers/index.html.erb
+++ b/app/views/account/trainers/index.html.erb
@@ -1,0 +1,32 @@
+<h1 class="font-bold text-4xl">Trainer Roster</h1>
+
+<div class="mt-8">
+  <% if @trainers.any? %>
+    <table class="w-full text-left border-collapse">
+      <thead>
+        <tr class="border-b border-gray-300">
+          <th class="py-3 px-4 font-semibold text-gray-700">Email</th>
+          <th class="py-3 px-4 font-semibold text-gray-700">Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @trainers.each do |trainer| %>
+          <tr class="border-b border-gray-200 hover:bg-gray-50">
+            <td class="py-3 px-4"><%= trainer.email_address %></td>
+            <td class="py-3 px-4">
+              <% if trainer.active? %>
+                <span class="inline-flex items-center rounded-full bg-green-50 px-2 py-1 text-xs font-medium text-green-700">Active</span>
+              <% elsif trainer.inactive? %>
+                <span class="inline-flex items-center rounded-full bg-red-50 px-2 py-1 text-xs font-medium text-red-700">Inactive</span>
+              <% else %>
+                <span class="inline-flex items-center rounded-full bg-yellow-50 px-2 py-1 text-xs font-medium text-yellow-700">Pending Password Change</span>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <p class="text-gray-500">No trainers in this account yet.</p>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
 
   namespace :account do
     resource :settings, only: [ :edit, :update ]
+    resources :trainers, only: [ :index ]
   end
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20260317193212_add_status_to_users.rb
+++ b/db/migrate/20260317193212_add_status_to_users.rb
@@ -1,0 +1,5 @@
+class AddStatusToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :status, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_15_093351) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_17_193212) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -35,6 +35,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_15_093351) do
     t.datetime "created_at", null: false
     t.string "email_address", null: false
     t.string "password_digest", null: false
+    t.integer "status", default: 0, null: false
     t.boolean "super_admin", default: false, null: false
     t.datetime "updated_at", null: false
     t.index ["client_id"], name: "index_users_on_client_id"

--- a/docs/app_spec.txt
+++ b/docs/app_spec.txt
@@ -72,7 +72,7 @@
     <account_management>
       - Account settings page for account_admins
       - Edit organization name
-      - Trainer roster: list all trainers with name, email, status (active/inactive)
+      - Trainer roster: list all trainers with email and status (active/inactive/pending_password_change); name will be shown once first_name/last_name columns are added
       - Invite new trainer: enter name + email; Rails generates a secure random
         password, creates the user with status pending_password_change, and sends an
         invitation email via Mailgun containing a one-time setup link

--- a/docs/feature_list.json
+++ b/docs/feature_list.json
@@ -945,5 +945,23 @@
       "Step 4: Verify the reset password form matches the overall design system"
     ],
     "passes": true
+  },
+  {
+    "category": "functional",
+    "description": "Account admin can view trainer roster with status",
+    "steps": [
+      "Step 1: Sign in as an account admin",
+      "Step 2: Navigate to /account/trainers",
+      "Step 3: Verify HTTP 200 response",
+      "Step 4: Verify all non-admin users belonging to the current client are listed",
+      "Step 5: Verify each row shows the trainer's email address",
+      "Step 6: Verify each row shows a status pill",
+      "Step 7: Verify active trainers show a green status pill",
+      "Step 8: Verify inactive trainers show a red status pill",
+      "Step 9: Verify pending_password_change trainers show a yellow status pill",
+      "Step 10: Verify account admin users are not shown in the list",
+      "Step 11: Verify trainers from other clients are not shown"
+    ],
+    "passes": true
   }
 ]

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -15,12 +15,21 @@ acme_trainer_one:
   password_digest: <%= password_digest %>
   super_admin: false
   client: acme
+  status: active
 
 acme_trainer_two:
   email_address: trainer2@acme.com
   password_digest: <%= password_digest %>
   super_admin: false
   client: acme
+  status: inactive
+
+acme_trainer_three:
+  email_address: trainer3@acme.com
+  password_digest: <%= password_digest %>
+  super_admin: false
+  client: acme
+  status: pending_password_change
 
 acme_admin:
   email_address: admin@acme.com

--- a/test/integration/account_trainers_test.rb
+++ b/test/integration/account_trainers_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class AccountTrainersIntegrationTest < ActionDispatch::IntegrationTest
+  setup do
+    @account_admin = users(:acme_admin)
+  end
+
+  test "trainer roster lists all trainers for the current client only" do
+    sign_in_as(@account_admin)
+
+    get account_trainers_path
+
+    assert_response :success
+    assert_select "td", text: users(:acme_trainer_one).email_address
+    assert_select "td", text: users(:acme_trainer_two).email_address
+    assert_select "td", text: users(:gamma_admin).email_address, count: 0
+  end
+
+  test "trainer roster displays correct status for each trainer" do
+    sign_in_as(@account_admin)
+
+    get account_trainers_path
+
+    assert_response :success
+    assert_select "span", text: "Active"
+    assert_select "span", text: "Inactive"
+    assert_select "span", text: "Pending Password Change"
+  end
+
+  test "account admin users are not shown in the trainer roster" do
+    sign_in_as(@account_admin)
+
+    get account_trainers_path
+
+    assert_response :success
+    assert_select "td", text: @account_admin.email_address, count: 0
+    assert_select "td", text: users(:acme_trainer_one).email_address
+  end
+
+  test "non-account-admin is blocked from trainer roster" do
+    sign_in_as(users(:acme_trainer_one))
+
+    get account_trainers_path
+
+    assert_redirected_to root_path
+  end
+end

--- a/test/integration/admin_clients_test.rb
+++ b/test/integration/admin_clients_test.rb
@@ -25,7 +25,7 @@ class AdminClientsIntegrationTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "tr", text: /Acme Corp/ do
-      assert_select "td", text: "2"
+      assert_select "td", text: "3"
     end
   end
 

--- a/test/system/account_trainers_test.rb
+++ b/test/system/account_trainers_test.rb
@@ -1,0 +1,22 @@
+require "application_system_test_case"
+
+class AccountTrainersTest < ApplicationSystemTestCase
+  test "account admin sees trainers listed with their status" do
+    account_admin = users(:acme_admin)
+
+    visit_and_confirm new_session_path, title: "Rocket"
+    fill_in "email_address", with: account_admin.email_address
+    fill_in "password", with: "password"
+    click_button "Sign in"
+    assert_current_path edit_account_settings_path
+
+    click_on "Trainer Roster"
+
+    assert_text users(:acme_trainer_one).email_address
+    assert_text users(:acme_trainer_two).email_address
+    assert_text users(:acme_trainer_three).email_address
+    assert_text "Active"
+    assert_text "Inactive"
+    assert_text "Pending Password Change"
+  end
+end


### PR DESCRIPTION
Adds a trainer roster page at `/account/trainers` where account admins can view all non-admin users in their organization with color-coded status pills (green for active, red for inactive, yellow for pending password change).

## Acceptance Criteria

- Navigating to the trainer roster page as an account admin returns HTTP 200.
- All trainers (non-admin users) belonging to the current client are listed.
- Each row shows the trainer's email and a status pill.
- Account admin users belonging to the same client are not shown in the list.
- Trainers from other clients are not shown.
- Status pills are color-coded: green (active), red (inactive), yellow (pending_password_change).

Closes #21