### PR TITLE
[docs] Update glossary - daily scan

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -42,11 +42,15 @@ Important domain terms for the Rocket training platform.
 
 **Status** — A user status enum with three values: `active` (can log in normally), `inactive` (soft-deactivated by an account admin; cannot log in), and `pending_password_change` (newly invited trainer who must set a password before accessing the application).
 
+**Status Pill** — A color-coded inline badge displayed in the trainer roster to indicate a trainer's current status. Green indicates `active`, red indicates `inactive`, and yellow indicates `pending_password_change`.
+
 **Super Admin** — A global system administrator identified by `super_admin: true` on the User model. Not associated with any client organization. Can create and delete client accounts.
 
 **Training Session** — A generated, shareable instance of a master training based on a specific version snapshot. Identified by a unique session slug. Can optionally be password-protected. Deleting a session does not affect the master training or other sessions.
 
 **Trainer** — A user belonging to exactly one client organization who creates master trainings, manages training content (slides, prerequisite assets, exercises), and generates training sessions.
+
+**Trainer Roster** — The page at `/account/trainers` where account admins can view all non-admin users in their organization. Displays each trainer's email and a color-coded status pill.
 
 **Trix Editor** — The rich text editor used for authoring exercise content, provided by Rails' Action Text library. Produces sanitized HTML output.
 


### PR DESCRIPTION
## Glossary Updates - 2026-03-18

### Scan Type
- [x] Incremental (daily - last 24 hours)
- [ ] Full scan (weekly - last 7 days)

### Terms Added
- **Status Pill**: Introduced by PR #23 (trainer roster feature). A color-coded inline badge showing trainer status in the trainer roster view.
- **Trainer Roster**: Introduced by PR #23. The new page at `/account/trainers` where account admins can view all trainers in their organization with status pills.

### Terms Updated
_(none)_

### Changes Analyzed
- Reviewed 6 commits from the last 24 hours
- Analyzed 1 merged PR (#23)

### Related Changes
- Commit `70f543c`: Add trainer roster page for account admins with status display
- PR #23: Account admin can view trainer roster with status

### Notes
The `Status` term was already present in the glossary. The two new terms (`Status Pill` and `Trainer Roster`) are the user-facing concepts added alongside the existing status enum definition.




> Generated by [Glossary Maintainer](https://github.com/jonaskay/rocket/actions/runs/23251683310) · [◷](https://github.com/search?q=repo%3Ajonaskay%2Frocket+%22gh-aw-workflow-id%3A+glossary-maintainer%22&type=pullrequests)
> - [x] expires <!-- gh-aw-expires: 2026-03-20T15:14:38.970Z --> on Mar 20, 2026, 3:14 PM UTC

<!-- gh-aw-agentic-workflow: Glossary Maintainer, engine: copilot, id: 23251683310, workflow_id: glossary-maintainer, run: https://github.com/jonaskay/rocket/actions/runs/23251683310 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: glossary-maintainer -->