### PR TITLE
[docs] Update glossary - daily scan

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -16,7 +16,7 @@ Important domain terms for the Rocket training platform.
 
 **Exercise Snapshot** — An immutable HTML copy of an exercise's rich text body captured at the time a training session is generated. Stored on the `exercise_snapshots` table as sanitized HTML.
 
-**Invitation Flow** — The process by which an account admin adds a new trainer to their organization. The system creates the trainer's account with `status: pending_password_change` and sends an invitation email containing a signed, time-limited link for the trainer to set their own password.
+**Invitation Flow** — The process by which an account admin adds a new trainer to their organization. The system creates the trainer's account with `status: pending_password_change` and sends an invitation email containing a signed, time-limited link. When the trainer follows the link and sets their password, their status is automatically transitioned to `active`, allowing them to log in immediately.
 
 **Master Training** — A reusable training template created and owned by a trainer. Contains slides, prerequisite assets, and exercises. Multiple training sessions can be generated from a single master training at different points in time.
 


### PR DESCRIPTION
## Glossary Updates - 2026-03-19

### Scan Type
- [x] Incremental (daily - last 24 hours)
- [ ] Full scan (weekly - last 7 days)

### Terms Added
_None_

### Terms Updated
- **Invitation Flow**: Extended definition to describe the automatic status transition from `pending_password_change` to `active` when an invited trainer sets their password via the invite link.

### Changes Analyzed
- Reviewed 7+ commits from the last 24 hours
- Analyzed 2 merged PRs: #44 (invite activation) and #43 (i18n)
- PR #44 completed the invite flow by implementing `PasswordsController#update` setting user status to `active` when previously `pending_password_change`

### Related Changes
- Commit `a193f26`: "Activate trainer status on password reset and block inactive login"
- PR #44: "Invited trainer can set password via invite link and log in"

### Notes
- PR #43 (i18n support) introduced standard Rails locale files; no new domain-specific glossary terms were needed.
- The `inactive` login blocking (also in PR #44) aligns with the existing Status definition which already states `inactive` users "cannot log in."




> Generated by [Glossary Maintainer](https://github.com/jonaskay/rocket/actions/runs/23290959470)
> - [x] expires <!-- gh-aw-expires: 2026-03-21T10:44:44.386Z --> on Mar 21, 2026, 10:44 AM UTC

<!-- gh-aw-agentic-workflow: Glossary Maintainer, engine: copilot, id: 23290959470, workflow_id: glossary-maintainer, run: https://github.com/jonaskay/rocket/actions/runs/23290959470 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: glossary-maintainer -->