### PR TITLE
[docs] Update glossary - daily scan

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -16,6 +16,8 @@ Important domain terms for the Rocket training platform.
 
 **Exercise Snapshot** — An immutable HTML copy of an exercise's rich text body captured at the time a training session is generated. Stored on the `exercise_snapshots` table as sanitized HTML.
 
+**Forced Password Change** — A security gate applied to trainers with `status: pending_password_change`. When such a trainer logs in, they are immediately redirected to `/account/password/edit` and cannot navigate to any other page until they set a new password. After submitting a valid password, their status is automatically transitioned to `active` and they are redirected to the home page.
+
 **Invitation Flow** — The process by which an account admin adds a new trainer to their organization. The system creates the trainer's account with `status: pending_password_change` and sends an invitation email containing a signed, time-limited link. When the trainer follows the link and sets their password, their status is automatically transitioned to `active`, allowing them to log in immediately.
 
 **Master Training** — A reusable training template created and owned by a trainer. Contains slides, prerequisite assets, and exercises. Multiple training sessions can be generated from a single master training at different points in time.


### PR DESCRIPTION
## Glossary Updates - 2026-03-20

### Scan Type
- [x] Incremental (daily - last 24 hours)
- [ ] Full scan (weekly - last 7 days)

### Terms Added
- **Forced Password Change**: Introduced by PR #48 which added a forced password change gate for newly invited trainers. When a `pending_password_change` trainer logs in, they are blocked from all other pages and must set a new password before proceeding.

### Terms Updated
_(none)_

### Changes Analyzed
- Reviewed 6 commits from the last 24 hours (since ~2026-03-19 10:39 UTC)
- Analyzed 2 merged PRs (#48, #49)

### Related Changes
- PR #48: Add forced password change on first login for invited trainers — introduced `Account::PasswordsController` and the `require_password_change_if_pending` before-action in the `Authentication` concern.
- PR #49: Fix corrupted docs/feature_list.json — no new domain terms.

### Notes
The existing **Invitation Flow** definition remains accurate; the forced password change gate complements it as a fallback activation mechanism for trainers who log in while still in `pending_password_change` status.




> Generated by [Glossary Maintainer](https://github.com/jonaskay/rocket/actions/runs/23339129099)
> - [x] expires <!-- gh-aw-expires: 2026-03-22T10:43:48.502Z --> on Mar 22, 2026, 10:43 AM UTC

<!-- gh-aw-agentic-workflow: Glossary Maintainer, engine: copilot, id: 23339129099, workflow_id: glossary-maintainer, run: https://github.com/jonaskay/rocket/actions/runs/23339129099 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: glossary-maintainer -->