### PR TITLE
[docs] Update glossary - weekly full scan

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -52,7 +52,9 @@ Important domain terms for the Rocket training platform.
 
 **Trainer** — A user belonging to exactly one client organization who creates master trainings, manages training content (slides, prerequisite assets, exercises), and generates training sessions.
 
-**Trainer Roster** — The page at `/account/trainers` where account admins can view all non-admin users in their organization. Displays each trainer's email and a color-coded status pill.
+**Trainer Removal** — The permanent, irreversible deletion of a trainer's user record initiated by an account admin from the Trainer Roster. Hard-deletes the user and all associated sessions. A confirmation dialog warns that the action cannot be undone before proceeding. Distinct from deactivation, which sets the trainer's status to `inactive` while preserving the record.
+
+**Trainer Roster** — The page at `/account/trainers` where account admins can view all non-admin users in their organization. Displays each trainer's email, a color-coded status pill, and an actions column. Active trainers show a Deactivate button; inactive trainers show a Reactivate button. All trainers show a Remove button that permanently deletes the trainer (see *Trainer Removal*).
 
 **Trix Editor** — The rich text editor used for authoring exercise content, provided by Rails' Action Text library. Produces sanitized HTML output.
 


### PR DESCRIPTION
## Glossary Updates - 2026-03-23

### Scan Type
- [ ] Incremental (daily - last 24 hours)
- [x] Full scan (weekly - last 7 days)

### Terms Added
- **Trainer Removal**: New permanent hard-delete action added in PR #63. Needed to clearly distinguish irreversible removal from soft deactivation, which preserves the user record.

### Terms Updated
- **Trainer Roster**: Updated definition to reflect the new Actions column introduced in PR #63. Now documents the Deactivate/Reactivate buttons and the new Remove button.

### Changes Analyzed
- Reviewed ~15 commits from the last 7 days (2026-03-17 to 2026-03-23)
- Analyzed 1 merged PR with glossary-relevant changes

### Related Changes
- Commit `e684286`: Add ability for account admins to permanently remove trainers
- PR #63: Account admin can permanently remove a trainer — adds Remove button to the Trainer Roster, hard-deletes user and cascades to associated sessions, with an irreversible confirmation dialog

### Notes
PR #59 (rename `issue.*` skills to `plan.*`) is unrelated to the Rocket training platform domain and was intentionally excluded from the glossary.




> Generated by [Glossary Maintainer](https://github.com/jonaskay/rocket/actions/runs/23433679414)
> - [x] expires <!-- gh-aw-expires: 2026-03-25T10:57:25.865Z --> on Mar 25, 2026, 10:57 AM UTC

<!-- gh-aw-agentic-workflow: Glossary Maintainer, engine: copilot, id: 23433679414, workflow_id: glossary-maintainer, run: https://github.com/jonaskay/rocket/actions/runs/23433679414 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: glossary-maintainer -->