### PR TITLE
[docs] Update glossary - daily scan

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -52,7 +52,7 @@ Important domain terms for the Rocket training platform.
 
 **Trainer** — A user belonging to exactly one client organization who creates master trainings, manages training content (slides, prerequisite assets, exercises), and generates training sessions.
 
-**Trainer Roster** — The page at `/account/trainers` where account admins can view all non-admin users in their organization. Displays each trainer's email and a color-coded status pill.
+**Trainer Roster** — The page at `/account/trainers` where account admins can view and manage all non-admin users in their organization. Displays each trainer's email and a color-coded status pill. Account admins can deactivate active trainers, reactivate inactive trainers, and permanently remove any trainer from the organization using action buttons on each row.
 
 **Trix Editor** — The rich text editor used for authoring exercise content, provided by Rails' Action Text library. Produces sanitized HTML output.
 


### PR DESCRIPTION
## Glossary Updates - 2026-03-24

### Scan Type
- [x] Incremental (daily - last 24 hours)
- [ ] Full scan (weekly - last 7 days)

### Terms Added
_(none)_

### Terms Updated
- **Trainer Roster**: Updated definition to reflect new management actions (deactivate, reactivate, permanently remove) added to the trainer roster page in PRs #58 and #63. The previous definition only described viewing trainers; the roster now includes action buttons for account admins.

### Changes Analyzed
- Reviewed commits from the last 24 hours (none found)
- Caught up on unprocessed commits since last scan (2026-03-18)
- Analyzed 2 merged PRs related to trainer management

### Related Changes
- Commit `e684286`: Add ability for account admins to permanently remove trainers
- Commit `2c32d75`: Implement deactivate and reactivate trainer feature (issue #42)
- PR #63: Account admin can permanently remove a trainer
- PR #58: Account admin can deactivate/reactivate trainers

### Notes
Cache updated to mark these commits as processed. Next scan should resume from 2026-03-24.




> Generated by [Glossary Maintainer](https://github.com/jonaskay/rocket/actions/runs/23485709176)
> - [x] expires <!-- gh-aw-expires: 2026-03-26T10:59:40.003Z --> on Mar 26, 2026, 10:59 AM UTC

<!-- gh-aw-agentic-workflow: Glossary Maintainer, engine: copilot, id: 23485709176, workflow_id: glossary-maintainer, run: https://github.com/jonaskay/rocket/actions/runs/23485709176 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: glossary-maintainer -->