### PR TITLE
[docs] Update glossary - daily scan

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -16,11 +16,13 @@ Important domain terms for the Rocket training platform.
 
 **Exercise Snapshot** — An immutable HTML copy of an exercise's rich text body captured at the time a training session is generated. Stored on the `exercise_snapshots` table as sanitized HTML.
 
-**Forced Password Change** — A security gate applied to trainers with `status: pending_password_change`. When such a trainer logs in, they are immediately redirected to `/account/password/edit` and cannot navigate to any other page until they set a new password. After submitting a valid password, their status is automatically transitioned to `active` and they are redirected to the home page.
+**Forced Password Change** — A security gate applied to trainers with `status: pending_password_change`. When such a trainer logs in, they are immediately redirected to `/account/password/edit` and cannot navigate to any other page until they set a new password. After submitting a valid password, their status is automatically transitioned to `active` and they are redirected to the master trainings dashboard (`/master_trainings`).
 
 **Invitation Flow** — The process by which an account admin adds a new trainer to their organization. The system creates the trainer's account with `status: pending_password_change` and sends an invitation email containing a signed, time-limited link. When the trainer follows the link and sets their password, their status is automatically transitioned to `active`, allowing them to log in immediately.
 
 **Master Training** — A reusable training template created and owned by a trainer. Contains slides, prerequisite assets, and exercises. Multiple training sessions can be generated from a single master training at different points in time.
+
+**Master Trainings Dashboard** — The page at `/master_trainings` where trainers can view all master trainings belonging to their account, displayed in a table ordered by most recently updated. Trainers are redirected here after login. Access is restricted to trainers; account admins and unauthenticated users are redirected away.
 
 **Password Gate** — The password entry page shown at `/s/:slug/unlock` when a training session is password-protected. Participants must submit the correct password before the session content is revealed.
 


### PR DESCRIPTION
## Glossary Updates - 2026-03-25

### Scan Type
- [x] Incremental (daily - last 24 hours)
- [ ] Full scan (weekly - last 7 days)

### Terms Added
- **Master Trainings Dashboard**: New page at `/master_trainings` introduced in PR #69 (issue #62). Trainers are redirected here after login and can view all their master trainings.

### Terms Updated
- **Forced Password Change**: Updated redirect destination from "the home page" to "the master trainings dashboard (`/master_trainings`)", reflecting the change made in PR #69.

### Changes Analyzed
- Reviewed 5 commits from 2026-03-24 (last 24 hours)
- Analyzed 1 merged pull request (PR #69)

### Related Changes
- Commit `76c024a`: Add master trainings dashboard for trainers (issue #62) — introduced the `/master_trainings` route and page
- Commit `331fb15`: Fix trainer removal FK violation and password change redirect — updated post-forced-password-change redirect to `master_trainings_path`
- PR #69: Add master trainings dashboard for trainers

### Notes
No ambiguous terms were found. All definitions match the implementation as described in the commit messages and code changes.




> Generated by [Glossary Maintainer](https://github.com/jonaskay/rocket/actions/runs/23537183419)
> - [x] expires <!-- gh-aw-expires: 2026-03-27T10:54:08.903Z --> on Mar 27, 2026, 10:54 AM UTC

<!-- gh-aw-agentic-workflow: Glossary Maintainer, engine: copilot, id: 23537183419, workflow_id: glossary-maintainer, run: https://github.com/jonaskay/rocket/actions/runs/23537183419 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: glossary-maintainer -->