### PR TITLE
[docs] Update glossary - daily scan

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -10,6 +10,8 @@ Important domain terms for the Rocket training platform.
 
 **Client** — A tenant organization in the multi-tenant system (also referred to as a "client account"). Each client has one account admin and one or more trainers. Managed by super admins.
 
+**Cross-Tenant Isolation** — The security mechanism that ensures each client organization's data remains strictly separate. Trainers can only access master trainings, training sessions, and other resources belonging to their own account; they cannot view or interact with another client's data.
+
 **Direct Upload** — A file upload method where files are sent directly from the browser to Google Cloud Storage using Active Storage's signed URL feature, bypassing the Rails server.
 
 **Exercise** — Rich text content associated with a master training, authored using the Trix editor and stored via Action Text. Supports headings, bold, italic, lists, links, image attachments, and code formatting.
@@ -21,6 +23,8 @@ Important domain terms for the Rocket training platform.
 **Invitation Flow** — The process by which an account admin adds a new trainer to their organization. The system creates the trainer's account with `status: pending_password_change` and sends an invitation email containing a signed, time-limited link. When the trainer follows the link and sets their password, their status is automatically transitioned to `active`, allowing them to log in immediately.
 
 **Master Training** — A reusable training template created and owned by a trainer. Contains slides, prerequisite assets, and exercises. Multiple training sessions can be generated from a single master training at different points in time.
+
+**Master Trainings Dashboard** — The page at `/master_trainings` where trainers can view all master trainings belonging to their account, displayed in a table ordered by most recently updated. This is the default landing page for trainers after login. Access is restricted to trainers; account admins and unauthenticated users are redirected away.
 
 **Password Gate** — The password entry page shown at `/s/:slug/unlock` when a training session is password-protected. Participants must submit the correct password before the session content is revealed.
 


### PR DESCRIPTION
## Glossary Updates - 2026-03-26

### Scan Type
- [x] Incremental (daily - last 24 hours)
- [ ] Full scan (weekly - last 7 days)

### Terms Added
- **Cross-Tenant Isolation**: New term to describe the security mechanism ensuring each client's data is strictly separated — introduced by PR #69 which added cross-tenant isolation tests and clarified that trainers can only see their own account's master trainings.
- **Master Trainings Dashboard**: New term for the trainer landing page at `/master_trainings` — introduced by PR #69 (issue #62), which added the dashboard as the default post-login destination for trainers.

### Terms Updated
_(none)_

### Changes Analyzed
- Reviewed 10+ commits from the past 48 hours
- Analyzed 2 merged PRs: #68 (trainer removal) and #69 (master trainings dashboard)

### Related Changes
- Commit `76c024a`: Add master trainings dashboard for trainers (issue #62)
- Commit `e684286`: Add ability for account admins to permanently remove trainers
- PR #69: Master Trainings Dashboard — trainers redirected here after login, cross-tenant isolation enforced
- PR #68: Trainer permanent removal added to Account Admin capabilities

### Notes
- The trainer removal feature (PR #68) is already partially covered by the existing **Account Admin** definition ("deactivate or remove trainers"), so no new term was needed for that.
- The **Forced Password Change** entry was updated in a prior commit to redirect to `master_trainings_path` instead of root; the glossary definition says "redirected to the home page" which remains accurate from the user's perspective.




> Generated by [Glossary Maintainer](https://github.com/jonaskay/rocket/actions/runs/23590461271)
> - [x] expires <!-- gh-aw-expires: 2026-03-28T10:57:24.700Z --> on Mar 28, 2026, 10:57 AM UTC

<!-- gh-aw-agentic-workflow: Glossary Maintainer, engine: copilot, id: 23590461271, workflow_id: glossary-maintainer, run: https://github.com/jonaskay/rocket/actions/runs/23590461271 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: glossary-maintainer -->