### PR TITLE
[docs] Update glossary - daily scan

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -16,11 +16,13 @@ Important domain terms for the Rocket training platform.
 
 **Exercise Snapshot** — An immutable HTML copy of an exercise's rich text body captured at the time a training session is generated. Stored on the `exercise_snapshots` table as sanitized HTML.
 
-**Forced Password Change** — A security gate applied to trainers with `status: pending_password_change`. When such a trainer logs in, they are immediately redirected to `/account/password/edit` and cannot navigate to any other page until they set a new password. After submitting a valid password, their status is automatically transitioned to `active` and they are redirected to the home page.
+**Forced Password Change** — A security gate applied to trainers with `status: pending_password_change`. When such a trainer logs in, they are immediately redirected to `/account/password/edit` and cannot navigate to any other page until they set a new password. After submitting a valid password, their status is automatically transitioned to `active` and they are redirected to the master trainings dashboard.
 
 **Invitation Flow** — The process by which an account admin adds a new trainer to their organization. The system creates the trainer's account with `status: pending_password_change` and sends an invitation email containing a signed, time-limited link. When the trainer follows the link and sets their password, their status is automatically transitioned to `active`, allowing them to log in immediately.
 
 **Master Training** — A reusable training template created and owned by a trainer. Contains slides, prerequisite assets, and exercises. Multiple training sessions can be generated from a single master training at different points in time.
+
+**Master Trainings Dashboard** — The page at `/master_trainings` where trainers can view all master trainings belonging to their account, listed in a table ordered by most recently updated. Trainers are automatically redirected here after sign-in. Shows an empty state message when no trainings exist. Accessible only to trainers; super admins and account admins are redirected away.
 
 **Password Gate** — The password entry page shown at `/s/:slug/unlock` when a training session is password-protected. Participants must submit the correct password before the session content is revealed.
 


### PR DESCRIPTION
## Glossary Updates - 2026-03-27

### Scan Type
- [x] Incremental (daily - last 24 hours)
- [ ] Full scan (weekly - last 7 days)

### Terms Added
- **Master Trainings Dashboard**: New page at `/master_trainings` introduced in PR #69 (issue #62). Trainers are automatically redirected here after sign-in.

### Terms Updated
- **Forced Password Change**: Updated redirect destination from "home page" to "master trainings dashboard", reflecting the fix in PR #69 follow-up commits that changed the post-password-change redirect from `root_path` to `master_trainings_path`.

### Changes Analyzed
- Reviewed 9 recent commits (most recent activity: 2026-03-24)
- Analyzed 2 merged PRs (#69, #63)
- No commits found within the last 24 hours; processed untracked changes from 2026-03-22 to 2026-03-24

### Related Changes
- PR #69 (98d5564): Add master trainings dashboard for trainers
- Commit 331fb15: Fix trainer removal FK violation and password change redirect (changed post-password-change redirect to `master_trainings_path`)

### Notes
This is the first run with no prior cache. Processed all recent untracked commits through 2026-03-24.




> Generated by [Glossary Maintainer](https://github.com/jonaskay/rocket/actions/runs/23642708615)
> - [x] expires <!-- gh-aw-expires: 2026-03-29T10:53:26.165Z --> on Mar 29, 2026, 10:53 AM UTC

<!-- gh-aw-agentic-workflow: Glossary Maintainer, engine: copilot, id: 23642708615, workflow_id: glossary-maintainer, run: https://github.com/jonaskay/rocket/actions/runs/23642708615 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: glossary-maintainer -->