### PR TITLE
[test] Extract shared helpers to reduce test duplication

### DIFF
--- a/test/integration/account_trainers_test.rb
+++ b/test/integration/account_trainers_test.rb
@@ -46,45 +46,15 @@ class AccountTrainersIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "admin removes an active trainer" do
-    sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_one)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_removal_succeeds users(:acme_trainer_one)
   end
 
   test "admin removes an inactive trainer" do
-    sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_two)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_removal_succeeds users(:acme_trainer_two)
   end
 
   test "admin removes a pending trainer" do
-    sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_three)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_removal_succeeds users(:acme_trainer_three)
   end
 
   test "admin fails to remove a trainer when destroy fails" do
@@ -126,5 +96,20 @@ class AccountTrainersIntegrationTest < ActionDispatch::IntegrationTest
 
     assert_response :not_found
     assert_equal original_attributes, other_trainer.reload.attributes
+  end
+
+  private
+
+  def assert_trainer_removal_succeeds(trainer)
+    sign_in_as(@account_admin)
+
+    assert_difference "User.count", -1 do
+      delete account_trainer_path(trainer)
+    end
+
+    assert_redirected_to account_trainers_path
+    follow_redirect!
+    assert_match trainer.email_address, flash[:notice]
+    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
   end
 end

--- a/test/system/account_trainers_test.rb
+++ b/test/system/account_trainers_test.rb
@@ -2,12 +2,7 @@ require "application_system_test_case"
 
 class AccountTrainersTest < ApplicationSystemTestCase
   test "account admin sees trainers listed with their status" do
-    account_admin = users(:acme_admin)
-
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+    sign_in_and_open_trainer_roster
 
     assert_text users(:acme_trainer_one).email_address
     assert_text users(:acme_trainer_two).email_address
@@ -19,13 +14,9 @@ class AccountTrainersTest < ApplicationSystemTestCase
   end
 
   test "admin removes a trainer from the roster" do
-    account_admin = users(:acme_admin)
     trainer = users(:acme_trainer_one)
 
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+    sign_in_and_open_trainer_roster
 
     assert_text trainer.email_address
     within("tr", text: trainer.email_address) do
@@ -39,13 +30,9 @@ class AccountTrainersTest < ApplicationSystemTestCase
   end
 
   test "admin deactivates an active trainer and reactivates them" do
-    account_admin = users(:acme_admin)
     trainer = users(:acme_trainer_one)
 
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+    sign_in_and_open_trainer_roster
 
     assert_text trainer.email_address
     within("tr", text: trainer.email_address) do
@@ -67,5 +54,13 @@ class AccountTrainersTest < ApplicationSystemTestCase
     within("tr", text: trainer.email_address) do
       assert_text "Active"
     end
+  end
+
+  private
+
+  def sign_in_and_open_trainer_roster
+    sign_in_via_ui users(:acme_admin)
+    assert_current_path edit_account_settings_path
+    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
   end
 end


### PR DESCRIPTION
Extracted two private helper methods replacing 6 total copy-pasted code blocks across integration and system tests.

### Helpers Extracted

- **`AccountTrainersIntegrationTest#assert_trainer_removal_succeeds(trainer)`** — replaces 3 identical delete+assert blocks across the 3 "admin removes a trainer" tests; only the trainer fixture differed
- **`AccountTrainersTest#sign_in_and_open_trainer_roster`** — replaces 3 identical 4-line preambles (sign in as acme_admin, assert path, navigate to Trainer Roster) across all system tests in that class

### Before / After

```ruby
# Before (repeated 3× in account_trainers_test.rb integration test)
test "admin removes an active trainer" do
  sign_in_as(`@account_admin`)
  trainer = users(:acme_trainer_one)

  assert_difference "User.count", -1 do
    delete account_trainer_path(trainer)
  end

  assert_redirected_to account_trainers_path
  follow_redirect!
  assert_match trainer.email_address, flash[:notice]
  assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
end

# After
test "admin removes an active trainer" do
  assert_trainer_removal_succeeds users(:acme_trainer_one)
end

# New private helper
def assert_trainer_removal_succeeds(trainer)
  sign_in_as(`@account_admin`)
  assert_difference "User.count", -1 do
    delete account_trainer_path(trainer)
  end
  assert_redirected_to account_trainers_path
  follow_redirect!
  assert_match trainer.email_address, flash[:notice]
  assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
end
```

```ruby
# Before (repeated 3× in account_trainers_test.rb system test)
account_admin = users(:acme_admin)
sign_in_via_ui account_admin
assert_current_path edit_account_settings_path
click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")

# After
sign_in_and_open_trainer_roster

# New private helper
def sign_in_and_open_trainer_roster
  sign_in_via_ui users(:acme_admin)
  assert_current_path edit_account_settings_path
  click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
end
```

### Files Changed
- `test/integration/account_trainers_test.rb` — 3 occurrences replaced (net −20 lines)
- `test/system/account_trainers_test.rb` — 3 occurrences replaced (net −9 lines)

**References:** [§23644716437](https://github.com/jonaskay/rocket/actions/runs/23644716437)




> Generated by [Test Cleanup Agent](https://github.com/jonaskay/rocket/actions/runs/23644716437)
> - [x] expires <!-- gh-aw-expires: 2026-03-29T11:54:57.565Z --> on Mar 29, 2026, 11:54 AM UTC

<!-- gh-aw-agentic-workflow: Test Cleanup Agent, engine: copilot, id: 23644716437, workflow_id: test-cleanup-agent, run: https://github.com/jonaskay/rocket/actions/runs/23644716437 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: test-cleanup-agent -->