### PR TITLE
[test] Extract shared helpers to reduce test duplication

### DIFF
--- a/test/integration/account_trainers_test.rb
+++ b/test/integration/account_trainers_test.rb
@@ -46,45 +46,15 @@ class AccountTrainersIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "admin removes an active trainer" do
-    sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_one)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_removes_trainer(users(:acme_trainer_one))
   end
 
   test "admin removes an inactive trainer" do
-    sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_two)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_removes_trainer(users(:acme_trainer_two))
   end
 
   test "admin removes a pending trainer" do
-    sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_three)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_removes_trainer(users(:acme_trainer_three))
   end
 
   test "admin fails to remove a trainer when destroy fails" do
@@ -126,5 +96,20 @@ class AccountTrainersIntegrationTest < ActionDispatch::IntegrationTest
 
     assert_response :not_found
     assert_equal original_attributes, other_trainer.reload.attributes
+  end
+
+  private
+
+  def assert_removes_trainer(trainer)
+    sign_in_as(@account_admin)
+
+    assert_difference "User.count", -1 do
+      delete account_trainer_path(trainer)
+    end
+
+    assert_redirected_to account_trainers_path
+    follow_redirect!
+    assert_match trainer.email_address, flash[:notice]
+    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
   end
 end

--- a/test/system/account_trainers_test.rb
+++ b/test/system/account_trainers_test.rb
@@ -2,12 +2,7 @@ require "application_system_test_case"
 
 class AccountTrainersTest < ApplicationSystemTestCase
   test "account admin sees trainers listed with their status" do
-    account_admin = users(:acme_admin)
-
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+    sign_in_and_visit_trainer_roster
 
     assert_text users(:acme_trainer_one).email_address
     assert_text users(:acme_trainer_two).email_address
@@ -19,13 +14,9 @@ class AccountTrainersTest < ApplicationSystemTestCase
   end
 
   test "admin removes a trainer from the roster" do
-    account_admin = users(:acme_admin)
     trainer = users(:acme_trainer_one)
 
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+    sign_in_and_visit_trainer_roster
 
     assert_text trainer.email_address
     within("tr", text: trainer.email_address) do
@@ -39,13 +30,9 @@ class AccountTrainersTest < ApplicationSystemTestCase
   end
 
   test "admin deactivates an active trainer and reactivates them" do
-    account_admin = users(:acme_admin)
     trainer = users(:acme_trainer_one)
 
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+    sign_in_and_visit_trainer_roster
 
     assert_text trainer.email_address
     within("tr", text: trainer.email_address) do
@@ -67,5 +54,13 @@ class AccountTrainersTest < ApplicationSystemTestCase
     within("tr", text: trainer.email_address) do
       assert_text "Active"
     end
+  end
+
+  private
+
+  def sign_in_and_visit_trainer_roster
+    sign_in_via_ui users(:acme_admin)
+    assert_current_path edit_account_settings_path
+    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
   end
 end


### PR DESCRIPTION
### Helpers Extracted

- **`AccountTrainersTest#sign_in_and_visit_trainer_roster`** — replaces 3 copy-pasted sign-in + navigation preambles in `test/system/account_trainers_test.rb`
- **`AccountTrainersIntegrationTest#assert_removes_trainer`** — replaces 3 copy-pasted delete + assertion blocks in `test/integration/account_trainers_test.rb`

### Before / After

```ruby
# Before — repeated 3 times in system/account_trainers_test.rb
account_admin = users(:acme_admin)

sign_in_via_ui account_admin
assert_current_path edit_account_settings_path

click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")

# After
sign_in_and_visit_trainer_roster
```

```ruby
# Before — repeated 3 times in integration/account_trainers_test.rb
sign_in_as(`@account_admin`)
trainer = users(:acme_trainer_xxx)

assert_difference "User.count", -1 do
  delete account_trainer_path(trainer)
end

assert_redirected_to account_trainers_path
follow_redirect!
assert_match trainer.email_address, flash[:notice]
assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }

# After
assert_removes_trainer(users(:acme_trainer_xxx))
```

### Files Changed

- `test/system/account_trainers_test.rb` — 3 preamble blocks replaced, `sign_in_and_visit_trainer_roster` added as private method
- `test/integration/account_trainers_test.rb` — 3 removal blocks replaced, `assert_removes_trainer` added as private method

### Stats

- 6 duplicate code blocks removed
- Net: −20 lines of test code

**References:** [§23739231482](https://github.com/jonaskay/rocket/actions/runs/23739231482)




> Generated by [Test Cleanup Agent](https://github.com/jonaskay/rocket/actions/runs/23739231482)
> - [x] expires <!-- gh-aw-expires: 2026-04-01T10:12:04.711Z --> on Apr 1, 2026, 10:12 AM UTC

<!-- gh-aw-agentic-workflow: Test Cleanup Agent, engine: copilot, id: 23739231482, workflow_id: test-cleanup-agent, run: https://github.com/jonaskay/rocket/actions/runs/23739231482 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: test-cleanup-agent -->