### PR TITLE
[docs] Update glossary - weekly full scan

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -16,11 +16,13 @@ Important domain terms for the Rocket training platform.
 
 **Exercise Snapshot** — An immutable HTML copy of an exercise's rich text body captured at the time a training session is generated. Stored on the `exercise_snapshots` table as sanitized HTML.
 
-**Forced Password Change** — A security gate applied to trainers with `status: pending_password_change`. When such a trainer logs in, they are immediately redirected to `/account/password/edit` and cannot navigate to any other page until they set a new password. After submitting a valid password, their status is automatically transitioned to `active` and they are redirected to the home page.
+**Forced Password Change** — A security gate applied to trainers with `status: pending_password_change`. When such a trainer logs in, they are immediately redirected to `/account/password/edit` and cannot navigate to any other page until they set a new password. After submitting a valid password, their status is automatically transitioned to `active` and they are redirected to the Master Trainings Dashboard.
 
 **Invitation Flow** — The process by which an account admin adds a new trainer to their organization. The system creates the trainer's account with `status: pending_password_change` and sends an invitation email containing a signed, time-limited link. When the trainer follows the link and sets their password, their status is automatically transitioned to `active`, allowing them to log in immediately.
 
 **Master Training** — A reusable training template created and owned by a trainer. Contains slides, prerequisite assets, and exercises. Multiple training sessions can be generated from a single master training at different points in time.
+
+**Master Trainings Dashboard** — The page at `/master_trainings` where trainers land after signing in. Displays all master trainings belonging to the trainer's client account in a table ordered by most recently updated, showing each training's title, description, and timestamps. Shows an empty state message when no trainings exist. Accessible to trainers only; super admins and client admins are redirected away.
 
 **Password Gate** — The password entry page shown at `/s/:slug/unlock` when a training session is password-protected. Participants must submit the correct password before the session content is revealed.
 


### PR DESCRIPTION
## Glossary Updates - 2026-03-30

### Scan Type
- [ ] Incremental (daily - last 24 hours)
- [x] Full scan (weekly - last 7 days)

### Terms Added
- **Master Trainings Dashboard**: New page at `/master_trainings` introduced in PR #69. Trainers land here after sign-in, viewing all master trainings in their account ordered by most recently updated.

### Terms Updated
- **Forced Password Change**: Updated redirect destination from "home page" to "Master Trainings Dashboard" to match the behaviour change in commit `331fb15` (part of issue #62 / PR #69 work).

### Changes Analyzed
- Reviewed 6 commits from the last 7 days (since 2026-03-23)
- Analyzed 1 merged PR

### Related Changes
- `76c024a`: Add master trainings dashboard for trainers (issue #62)
- `331fb15`: Fix trainer removal FK violation and password change redirect
- PR #69: Add master trainings dashboard for trainers

### Notes
No other new user-facing terminology was identified in the weekly scan. The `require_trainer` guard is an internal implementation detail and was intentionally excluded.




> Generated by [Glossary Maintainer](https://github.com/jonaskay/rocket/actions/runs/23741404506)
> - [x] expires <!-- gh-aw-expires: 2026-04-01T11:05:57.165Z --> on Apr 1, 2026, 11:05 AM UTC

<!-- gh-aw-agentic-workflow: Glossary Maintainer, engine: copilot, id: 23741404506, workflow_id: glossary-maintainer, run: https://github.com/jonaskay/rocket/actions/runs/23741404506 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: glossary-maintainer -->