### PR TITLE
[docs] Update glossary - daily scan

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -16,11 +16,13 @@ Important domain terms for the Rocket training platform.
 
 **Exercise Snapshot** — An immutable HTML copy of an exercise's rich text body captured at the time a training session is generated. Stored on the `exercise_snapshots` table as sanitized HTML.
 
-**Forced Password Change** — A security gate applied to trainers with `status: pending_password_change`. When such a trainer logs in, they are immediately redirected to `/account/password/edit` and cannot navigate to any other page until they set a new password. After submitting a valid password, their status is automatically transitioned to `active` and they are redirected to the home page.
+**Forced Password Change** — A security gate applied to trainers with `status: pending_password_change`. When such a trainer logs in, they are immediately redirected to `/account/password/edit` and cannot navigate to any other page until they set a new password. After submitting a valid password, their status is automatically transitioned to `active` and they are redirected to the master trainings dashboard.
 
 **Invitation Flow** — The process by which an account admin adds a new trainer to their organization. The system creates the trainer's account with `status: pending_password_change` and sends an invitation email containing a signed, time-limited link. When the trainer follows the link and sets their password, their status is automatically transitioned to `active`, allowing them to log in immediately.
 
 **Master Training** — A reusable training template created and owned by a trainer. Contains slides, prerequisite assets, and exercises. Multiple training sessions can be generated from a single master training at different points in time.
+
+**Master Trainings Dashboard** — The page at `/master_trainings` where trainers can view all master trainings belonging to their client account, displayed in a table ordered by most recently updated. Trainers are redirected here after signing in and after completing a forced password change. Account admins and unauthenticated users are redirected away from this page.
 
 **Password Gate** — The password entry page shown at `/s/:slug/unlock` when a training session is password-protected. Participants must submit the correct password before the session content is revealed.
 


### PR DESCRIPTION
## Glossary Updates - 2026-04-03

### Scan Type
- [x] Incremental (daily - last 24 hours)
- [ ] Full scan (weekly - last 7 days)

### Terms Added
- **Master Trainings Dashboard**: New page at `/master_trainings` introduced in issue #62 (commit 76c024a). Trainers land here after login and after a forced password change.

### Terms Updated
- **Forced Password Change**: Updated post-password-change redirect from "the home page" to "the master trainings dashboard", reflecting the change in commit 331fb15.

### Changes Analyzed
- Reviewed recent commits; caught up on March 24 commits (76c024a, 331fb15, 5085def, c09b627, 98d5564) that were not previously processed for glossary terms.

### Related Changes
- `76c024a`: Add master trainings dashboard for trainers (issue #62) — introduced the `/master_trainings` route and dashboard concept
- `331fb15`: Fix trainer removal FK violation and password change redirect — changed forced password change redirect to `master_trainings_path`
- PR #69: Add master trainings dashboard for trainers

### Notes
All currently known commits have been processed and added to the glossary cache.




> Generated by [Glossary Maintainer](https://github.com/jonaskay/rocket/actions/runs/23943514382)
> - [x] expires <!-- gh-aw-expires: 2026-04-05T10:48:26.878Z --> on Apr 5, 2026, 10:48 AM UTC

<!-- gh-aw-agentic-workflow: Glossary Maintainer, engine: copilot, id: 23943514382, workflow_id: glossary-maintainer, run: https://github.com/jonaskay/rocket/actions/runs/23943514382 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: glossary-maintainer -->