### PR TITLE
[docs] Update glossary - weekly full scan

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -16,11 +16,13 @@ Important domain terms for the Rocket training platform.
 
 **Exercise Snapshot** — An immutable HTML copy of an exercise's rich text body captured at the time a training session is generated. Stored on the `exercise_snapshots` table as sanitized HTML.
 
-**Forced Password Change** — A security gate applied to trainers with `status: pending_password_change`. When such a trainer logs in, they are immediately redirected to `/account/password/edit` and cannot navigate to any other page until they set a new password. After submitting a valid password, their status is automatically transitioned to `active` and they are redirected to the home page.
+**Forced Password Change** — A security gate applied to trainers with `status: pending_password_change`. When such a trainer logs in, they are immediately redirected to `/account/password/edit` and cannot navigate to any other page until they set a new password. After submitting a valid password, their status is automatically transitioned to `active` and they are redirected to the Master Trainings Dashboard.
 
 **Invitation Flow** — The process by which an account admin adds a new trainer to their organization. The system creates the trainer's account with `status: pending_password_change` and sends an invitation email containing a signed, time-limited link. When the trainer follows the link and sets their password, their status is automatically transitioned to `active`, allowing them to log in immediately.
 
 **Master Training** — A reusable training template created and owned by a trainer. Contains slides, prerequisite assets, and exercises. Multiple training sessions can be generated from a single master training at different points in time.
+
+**Master Trainings Dashboard** — The page at `/master_trainings` where trainers can view all master trainings belonging to their account, ordered by most recently updated. Trainers are redirected here immediately after login. Access is restricted to trainers only; account admins and unauthenticated users are redirected away.
 
 **Password Gate** — The password entry page shown at `/s/:slug/unlock` when a training session is password-protected. Participants must submit the correct password before the session content is revealed.
 


### PR DESCRIPTION
## Glossary Updates - 2026-04-06

### Scan Type
- [ ] Incremental (daily - last 24 hours)
- [x] Full scan (weekly - last 7 days, run on Monday)

### Terms Added
- **Master Trainings Dashboard**: New user-facing page at `/master_trainings` introduced by issue #62 / PR #69. Trainers are redirected here after login and can view all their master trainings ordered by most recently updated.

### Terms Updated
- **Forced Password Change**: Updated redirect destination from "the home page" to "the Master Trainings Dashboard" — reflects commit `331fb15` which changed the post-password-change redirect from `root_path` to `master_trainings_path`.

### Changes Analyzed
- Reviewed 20 recent commits
- Most recent activity: 2026-03-27 (no commits in the last 7 days)
- Analyzed merged PR #69 and related commits

### Related Changes
- Commit `76c024a`: Add master trainings dashboard for trainers (issue #62)
- Commit `331fb15`: Fix trainer removal FK violation and password change redirect
- PR #69: Add master trainings dashboard for trainers

### Notes
Alphabetical order is preserved: **Master Training** appears before **Master Trainings Dashboard**.




> Generated by [Glossary Maintainer](https://github.com/jonaskay/rocket/actions/runs/24029149984)
> - [x] expires <!-- gh-aw-expires: 2026-04-08T11:02:10.556Z --> on Apr 8, 2026, 11:02 AM UTC

<!-- gh-aw-agentic-workflow: Glossary Maintainer, engine: copilot, id: 24029149984, workflow_id: glossary-maintainer, run: https://github.com/jonaskay/rocket/actions/runs/24029149984 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: glossary-maintainer -->