### PR TITLE
[docs] Update glossary - daily scan

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -22,6 +22,8 @@ Important domain terms for the Rocket training platform.
 
 **Master Training** — A reusable training template created and owned by a trainer. Contains slides, prerequisite assets, and exercises. Multiple training sessions can be generated from a single master training at different points in time.
 
+**Master Trainings Dashboard** — The page at `/master_trainings` where trainers can view all master trainings for their account in a table ordered by most recently updated. Access is restricted to trainers only; admins and unauthenticated users are redirected away. This is also the page trainers are redirected to after logging in.
+
 **Password Gate** — The password entry page shown at `/s/:slug/unlock` when a training session is password-protected. Participants must submit the correct password before the session content is revealed.
 
 **Prerequisite Asset** — A file of any type (PDF, video, ZIP, etc.) attached to a master training that participants are expected to review or download before the training session begins.


### PR DESCRIPTION
## Glossary Updates - 2026-04-10

### Scan Type
- [x] Incremental (daily - last 24 hours)
- [ ] Full scan (weekly - last 7 days)

### Terms Added
- **Master Trainings Dashboard**: Added to reflect the trainer-facing dashboard at `/master_trainings` introduced in PR #69. This term was identified in the previous scan but the corresponding PR was not created/merged.

### Terms Updated
_(none)_

### Changes Analyzed
- Reviewed 10 recent commits
- Confirmed no new commits since the last scan (2026-04-03)
- Identified gap: "Master Trainings Dashboard" was in cache as added but missing from the glossary

### Related Changes
- Commit 76c024a: Add master trainings dashboard for trainers (issue #62)
- Commit 331fb15: Fix trainer removal FK violation and password change redirect (updates post-login redirect to master_trainings_path)
- PR #69: Add master trainings dashboard for trainers

### Notes
The previous daily scan (2026-04-03) identified this term but the PR was not created. This run adds the missing term.




> Generated by [Glossary Maintainer](https://github.com/jonaskay/rocket/actions/runs/24239469602)
> - [x] expires <!-- gh-aw-expires: 2026-04-12T10:58:05.027Z --> on Apr 12, 2026, 10:58 AM UTC

<!-- gh-aw-agentic-workflow: Glossary Maintainer, engine: copilot, id: 24239469602, workflow_id: glossary-maintainer, run: https://github.com/jonaskay/rocket/actions/runs/24239469602 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: glossary-maintainer -->