### PR TITLE
[test] Extract shared helpers to reduce test duplication

### DIFF
--- a/test/integration/account_trainers_test.rb
+++ b/test/integration/account_trainers_test.rb
@@ -46,45 +46,15 @@ class AccountTrainersIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "admin removes an active trainer" do
-    sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_one)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_successfully_removed(users(:acme_trainer_one))
   end
 
   test "admin removes an inactive trainer" do
-    sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_two)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_successfully_removed(users(:acme_trainer_two))
   end
 
   test "admin removes a pending trainer" do
-    sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_three)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_successfully_removed(users(:acme_trainer_three))
   end
 
   test "admin fails to remove a trainer when destroy fails" do
@@ -126,5 +96,20 @@ class AccountTrainersIntegrationTest < ActionDispatch::IntegrationTest
 
     assert_response :not_found
     assert_equal original_attributes, other_trainer.reload.attributes
+  end
+
+  private
+
+  def assert_trainer_successfully_removed(trainer)
+    sign_in_as(@account_admin)
+
+    assert_difference "User.count", -1 do
+      delete account_trainer_path(trainer)
+    end
+
+    assert_redirected_to account_trainers_path
+    follow_redirect!
+    assert_match trainer.email_address, flash[:notice]
+    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
   end
 end

--- a/test/system/account_trainers_test.rb
+++ b/test/system/account_trainers_test.rb
@@ -4,10 +4,7 @@ class AccountTrainersTest < ApplicationSystemTestCase
   test "account admin sees trainers listed with their status" do
     account_admin = users(:acme_admin)
 
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+    navigate_to_trainer_roster(account_admin)
 
     assert_text users(:acme_trainer_one).email_address
     assert_text users(:acme_trainer_two).email_address
@@ -22,10 +19,7 @@ class AccountTrainersTest < ApplicationSystemTestCase
     account_admin = users(:acme_admin)
     trainer = users(:acme_trainer_one)
 
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+    navigate_to_trainer_roster(account_admin)
 
     assert_text trainer.email_address
     within("tr", text: trainer.email_address) do
@@ -42,10 +36,7 @@ class AccountTrainersTest < ApplicationSystemTestCase
     account_admin = users(:acme_admin)
     trainer = users(:acme_trainer_one)
 
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+    navigate_to_trainer_roster(account_admin)
 
     assert_text trainer.email_address
     within("tr", text: trainer.email_address) do
@@ -67,5 +58,13 @@ class AccountTrainersTest < ApplicationSystemTestCase
     within("tr", text: trainer.email_address) do
       assert_text "Active"
     end
+  end
+
+  private
+
+  def navigate_to_trainer_roster(account_admin)
+    sign_in_via_ui account_admin
+    assert_current_path edit_account_settings_path
+    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
   end
 end


### PR DESCRIPTION
### Test Cleanup

Scanned all test files in `test/integration/` and `test/system/` for repeated code blocks appearing 3+ times. Found two clear patterns in the trainer-related test files.

### Helpers Extracted

- **`AccountTrainersIntegrationTest#assert_trainer_successfully_removed`** — replaces 3 copy-pasted remove-trainer blocks in `test/integration/account_trainers_test.rb`
- **`AccountTrainersTest#navigate_to_trainer_roster`** — replaces 3 copy-pasted sign-in + navigate blocks in `test/system/account_trainers_test.rb`

### Before / After

#### Integration test — remove trainer pattern

```ruby
# Before (repeated 3 times, differing only in trainer fixture)
test "admin removes an active trainer" do
  sign_in_as(`@account_admin`)
  trainer = users(:acme_trainer_one)

  assert_difference "User.count", -1 do
    delete account_trainer_path(trainer)
  end

  assert_redirected_to account_trainers_path
  follow_redirect!
  assert_match trainer.email_address, flash[:notice]
  assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
end

# After
test "admin removes an active trainer" do
  assert_trainer_successfully_removed(users(:acme_trainer_one))
end

# Extracted private helper
def assert_trainer_successfully_removed(trainer)
  sign_in_as(`@account_admin`)
  assert_difference "User.count", -1 do
    delete account_trainer_path(trainer)
  end
  assert_redirected_to account_trainers_path
  follow_redirect!
  assert_match trainer.email_address, flash[:notice]
  assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
end
```

#### System test — navigate to trainer roster pattern

```ruby
# Before (repeated 3 times across all tests in the class)
sign_in_via_ui account_admin
assert_current_path edit_account_settings_path
click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")

# After
navigate_to_trainer_roster(account_admin)

# Extracted private helper
def navigate_to_trainer_roster(account_admin)
  sign_in_via_ui account_admin
  assert_current_path edit_account_settings_path
  click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
end
```

### Files Changed

- `test/integration/account_trainers_test.rb` — 3 occurrences replaced; private helper added
- `test/system/account_trainers_test.rb` — 3 occurrences replaced; private helper added

### Stats

- **6 duplicate blocks removed** (3 per file)
- **Net change**: −16 lines (29 insertions, 45 deletions)
- Both helpers are scoped as `private` within their test class — no shared module changes needed

**References:** [§24338410207](https://github.com/jonaskay/rocket/actions/runs/24338410207)




> Generated by [Test Cleanup Agent](https://github.com/jonaskay/rocket/actions/runs/24338410207)
> - [x] expires <!-- gh-aw-expires: 2026-04-15T10:33:05.115Z --> on Apr 15, 2026, 10:33 AM UTC

<!-- gh-aw-agentic-workflow: Test Cleanup Agent, engine: copilot, id: 24338410207, workflow_id: test-cleanup-agent, run: https://github.com/jonaskay/rocket/actions/runs/24338410207 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: test-cleanup-agent -->