### PR TITLE
[docs] Update glossary - weekly full scan

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -16,11 +16,13 @@ Important domain terms for the Rocket training platform.
 
 **Exercise Snapshot** — An immutable HTML copy of an exercise's rich text body captured at the time a training session is generated. Stored on the `exercise_snapshots` table as sanitized HTML.
 
-**Forced Password Change** — A security gate applied to trainers with `status: pending_password_change`. When such a trainer logs in, they are immediately redirected to `/account/password/edit` and cannot navigate to any other page until they set a new password. After submitting a valid password, their status is automatically transitioned to `active` and they are redirected to the home page.
+**Forced Password Change** — A security gate applied to trainers with `status: pending_password_change`. When such a trainer logs in, they are immediately redirected to `/account/password/edit` and cannot navigate to any other page until they set a new password. After submitting a valid password, their status is automatically transitioned to `active` and they are redirected to the master trainings dashboard.
 
 **Invitation Flow** — The process by which an account admin adds a new trainer to their organization. The system creates the trainer's account with `status: pending_password_change` and sends an invitation email containing a signed, time-limited link. When the trainer follows the link and sets their password, their status is automatically transitioned to `active`, allowing them to log in immediately.
 
 **Master Training** — A reusable training template created and owned by a trainer. Contains slides, prerequisite assets, and exercises. Multiple training sessions can be generated from a single master training at different points in time.
+
+**Master Trainings Dashboard** — The page at `/master_trainings` that serves as the home screen for trainers after sign-in. Lists all master trainings belonging to the trainer's client account (including trainings created by other trainers in the same account), ordered by most recently updated. Displays each training's title, description, and created/updated timestamps. Shows an empty state message when no trainings exist. Not accessible to super admins, account admins, or unauthenticated users.
 
 **Password Gate** — The password entry page shown at `/s/:slug/unlock` when a training session is password-protected. Participants must submit the correct password before the session content is revealed.
 


### PR DESCRIPTION
## Glossary Updates - 2026-04-13

### Scan Type
- [ ] Incremental (daily - last 24 hours)
- [x] Full scan (weekly - last 7 days)

> **Note:** Cache was empty (first run). Reviewed recent commits since March 2026 to ensure glossary accuracy.

### Terms Added
- **Master Trainings Dashboard**: New page (`/master_trainings`) introduced in PR #69 serving as the trainer home screen after sign-in. Not previously documented in the glossary.

### Terms Updated
- **Forced Password Change**: Updated redirect destination from "home page" to "master trainings dashboard", reflecting the change in commit `331fb15` which switched the post-password-change redirect from `root_path` to `master_trainings_path`.

### Changes Analyzed
- Reviewed 6 commits from the last few weeks
- Analyzed 1 merged PR (PR #69)
- Processed 1 new feature (master trainings dashboard)

### Related Changes
- Commit `76c024a`: Add master trainings dashboard for trainers (issue #62)
- Commit `331fb15`: Fix trainer removal FK violation and password change redirect — updates post-forced-password-change redirect to `master_trainings_path`
- PR #69: Add master trainings dashboard for trainers

### Notes
No commits found within the strict last-7-days window. Glossary was reviewed against recent merged changes to ensure accuracy.




> Generated by [Glossary Maintainer](https://github.com/jonaskay/rocket/actions/runs/24340455760)
> - [x] expires <!-- gh-aw-expires: 2026-04-15T11:21:38.129Z --> on Apr 15, 2026, 11:21 AM UTC

<!-- gh-aw-agentic-workflow: Glossary Maintainer, engine: copilot, id: 24340455760, workflow_id: glossary-maintainer, run: https://github.com/jonaskay/rocket/actions/runs/24340455760 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: glossary-maintainer -->