### PR TITLE
[test] Extract shared helpers to reduce test duplication

### DIFF
--- a/test/integration/account_trainers_test.rb
+++ b/test/integration/account_trainers_test.rb
@@ -47,44 +47,17 @@ class AccountTrainersIntegrationTest < ActionDispatch::IntegrationTest
 
   test "admin removes an active trainer" do
     sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_one)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_removed(users(:acme_trainer_one))
   end
 
   test "admin removes an inactive trainer" do
     sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_two)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_removed(users(:acme_trainer_two))
   end
 
   test "admin removes a pending trainer" do
     sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_three)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_removed(users(:acme_trainer_three))
   end
 
   test "admin fails to remove a trainer when destroy fails" do
@@ -126,5 +99,18 @@ class AccountTrainersIntegrationTest < ActionDispatch::IntegrationTest
 
     assert_response :not_found
     assert_equal original_attributes, other_trainer.reload.attributes
+  end
+
+  private
+
+  def assert_trainer_removed(trainer)
+    assert_difference "User.count", -1 do
+      delete account_trainer_path(trainer)
+    end
+
+    assert_redirected_to account_trainers_path
+    follow_redirect!
+    assert_match trainer.email_address, flash[:notice]
+    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
   end
 end

--- a/test/system/account_trainers_test.rb
+++ b/test/system/account_trainers_test.rb
@@ -1,13 +1,12 @@
 require "application_system_test_case"
 
 class AccountTrainersTest < ApplicationSystemTestCase
+  setup do
+    @account_admin = users(:acme_admin)
+  end
+
   test "account admin sees trainers listed with their status" do
-    account_admin = users(:acme_admin)
-
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+    navigate_to_trainer_roster
 
     assert_text users(:acme_trainer_one).email_address
     assert_text users(:acme_trainer_two).email_address
@@ -19,13 +18,9 @@ class AccountTrainersTest < ApplicationSystemTestCase
   end
 
   test "admin removes a trainer from the roster" do
-    account_admin = users(:acme_admin)
     trainer = users(:acme_trainer_one)
 
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+    navigate_to_trainer_roster
 
     assert_text trainer.email_address
     within("tr", text: trainer.email_address) do
@@ -39,13 +34,9 @@ class AccountTrainersTest < ApplicationSystemTestCase
   end
 
   test "admin deactivates an active trainer and reactivates them" do
-    account_admin = users(:acme_admin)
     trainer = users(:acme_trainer_one)
 
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+    navigate_to_trainer_roster
 
     assert_text trainer.email_address
     within("tr", text: trainer.email_address) do
@@ -67,5 +58,13 @@ class AccountTrainersTest < ApplicationSystemTestCase
     within("tr", text: trainer.email_address) do
       assert_text "Active"
     end
+  end
+
+  private
+
+  def navigate_to_trainer_roster
+    sign_in_via_ui @account_admin
+    assert_current_path edit_account_settings_path
+    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
   end
 end


### PR DESCRIPTION
### Helpers Extracted

- **`AccountTrainersIntegrationTest#assert_trainer_removed`** — replaces 3 copy-pasted delete+assert blocks that differed only in which trainer fixture was used
- **`AccountTrainersTest#navigate_to_trainer_roster`** — replaces 3 identical sign-in + navigation sequences in system tests (also adds a `setup` block to assign `@account_admin`)

### Before / After

```ruby
# Before (repeated 3× in test/integration/account_trainers_test.rb)
sign_in_as(`@account_admin`)
trainer = users(:acme_trainer_one)   # only this line differed

assert_difference "User.count", -1 do
  delete account_trainer_path(trainer)
end

assert_redirected_to account_trainers_path
follow_redirect!
assert_match trainer.email_address, flash[:notice]
assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }

# After
sign_in_as(`@account_admin`)
assert_trainer_removed(users(:acme_trainer_one))
```

```ruby
# Before (repeated 3× in test/system/account_trainers_test.rb)
account_admin = users(:acme_admin)
sign_in_via_ui account_admin
assert_current_path edit_account_settings_path
click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")

# After
navigate_to_trainer_roster   # `@account_admin` set in setup
```

### Files Changed
- `test/integration/account_trainers_test.rb` — 3 occurrences replaced, private `assert_trainer_removed` helper added
- `test/system/account_trainers_test.rb` — 3 occurrences replaced, `setup` block and private `navigate_to_trainer_roster` helper added

**Net change: 15 fewer lines, 6 duplicate blocks eliminated**

**References:** [§24661432367](https://github.com/jonaskay/rocket/actions/runs/24661432367)




> Generated by [Test Cleanup Agent](https://github.com/jonaskay/rocket/actions/runs/24661432367)
> - [x] expires <!-- gh-aw-expires: 2026-04-22T10:33:41.001Z --> on Apr 22, 2026, 10:33 AM UTC

<!-- gh-aw-agentic-workflow: Test Cleanup Agent, engine: copilot, id: 24661432367, workflow_id: test-cleanup-agent, run: https://github.com/jonaskay/rocket/actions/runs/24661432367 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: test-cleanup-agent -->