### PR TITLE
[docs] Update glossary - daily scan

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -16,11 +16,13 @@ Important domain terms for the Rocket training platform.
 
 **Exercise Snapshot** — An immutable HTML copy of an exercise's rich text body captured at the time a training session is generated. Stored on the `exercise_snapshots` table as sanitized HTML.
 
-**Forced Password Change** — A security gate applied to trainers with `status: pending_password_change`. When such a trainer logs in, they are immediately redirected to `/account/password/edit` and cannot navigate to any other page until they set a new password. After submitting a valid password, their status is automatically transitioned to `active` and they are redirected to the home page.
+**Forced Password Change** — A security gate applied to trainers with `status: pending_password_change`. When such a trainer logs in, they are immediately redirected to `/account/password/edit` and cannot navigate to any other page until they set a new password. After submitting a valid password, their status is automatically transitioned to `active` and they are redirected to the master trainings dashboard.
 
 **Invitation Flow** — The process by which an account admin adds a new trainer to their organization. The system creates the trainer's account with `status: pending_password_change` and sends an invitation email containing a signed, time-limited link. When the trainer follows the link and sets their password, their status is automatically transitioned to `active`, allowing them to log in immediately.
 
 **Master Training** — A reusable training template created and owned by a trainer. Contains slides, prerequisite assets, and exercises. Multiple training sessions can be generated from a single master training at different points in time.
+
+**Master Trainings Dashboard** — The trainer home screen at `/master_trainings`. Displays a table of all master trainings for the trainer's account, ordered by most recently updated. Serves as the post-login and post-password-change landing page for trainers. Access is restricted to trainers only; account admins and unauthenticated users are redirected away.
 
 **Password Gate** — The password entry page shown at `/s/:slug/unlock` when a training session is password-protected. Participants must submit the correct password before the session content is revealed.
 


### PR DESCRIPTION
## Glossary Updates - 2026-04-24

### Scan Type
- [x] Incremental (daily - last 24 hours)
- [ ] Full scan (weekly - last 7 days)

> **Note:** No new commits found in the last 24 hours (most recent commit: `2117c5a` from 2026-03-27). However, PR #96 (a prior weekly scan PR) was closed on 2026-04-15 without merging, leaving two pending glossary changes unapplied. This PR applies those changes.

### Terms Added
- **Master Trainings Dashboard**: New page (`/master_trainings`) introduced in PR #69. Serves as the trainer home screen after sign-in and after a forced password change. Not previously in the glossary.

### Terms Updated
- **Forced Password Change**: Corrected redirect destination from "home page" to "master trainings dashboard", reflecting the change in commit `331fb15` which switched the post-password-change redirect from `root_path` to `master_trainings_path`.

### Changes Analyzed
- Reviewed 0 new commits (no activity in the last 24 hours)
- Prior PR #96 was found closed (not merged) — its changes are re-applied here

### Related Changes
- Commit `76c024a`: Add master trainings dashboard for trainers (issue #62)
- Commit `331fb15`: Fix trainer removal FK violation and password change redirect
- PR #69: Add master trainings dashboard for trainers
- PR #96: Prior glossary PR (closed without merging on 2026-04-15)

### Notes
Cache shows last scan was 2026-04-15. No new commits since then, but the stale PR #96 prompted these corrections.




> Generated by [Glossary Maintainer](https://github.com/jonaskay/rocket/actions/runs/24886272248)
> - [x] expires <!-- gh-aw-expires: 2026-04-26T11:11:25.552Z --> on Apr 26, 2026, 11:11 AM UTC

<!-- gh-aw-agentic-workflow: Glossary Maintainer, engine: copilot, id: 24886272248, workflow_id: glossary-maintainer, run: https://github.com/jonaskay/rocket/actions/runs/24886272248 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: glossary-maintainer -->