### PR TITLE
[test] Extract shared helpers to reduce test duplication

### DIFF
--- a/test/integration/account_trainers_test.rb
+++ b/test/integration/account_trainers_test.rb
@@ -47,44 +47,17 @@ class AccountTrainersIntegrationTest < ActionDispatch::IntegrationTest
 
   test "admin removes an active trainer" do
     sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_one)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_removed(users(:acme_trainer_one))
   end
 
   test "admin removes an inactive trainer" do
     sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_two)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_removed(users(:acme_trainer_two))
   end
 
   test "admin removes a pending trainer" do
     sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_three)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_removed(users(:acme_trainer_three))
   end
 
   test "admin fails to remove a trainer when destroy fails" do
@@ -126,5 +99,18 @@ class AccountTrainersIntegrationTest < ActionDispatch::IntegrationTest
 
     assert_response :not_found
     assert_equal original_attributes, other_trainer.reload.attributes
+  end
+
+  private
+
+  def assert_trainer_removed(trainer)
+    assert_difference "User.count", -1 do
+      delete account_trainer_path(trainer)
+    end
+
+    assert_redirected_to account_trainers_path
+    follow_redirect!
+    assert_match trainer.email_address, flash[:notice]
+    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
   end
 end

--- a/test/integration/forced_password_change_test.rb
+++ b/test/integration/forced_password_change_test.rb
@@ -1,25 +1,25 @@
 require "test_helper"
 
 class ForcedPasswordChangeTest < ActionDispatch::IntegrationTest
-  test "pending user is redirected to change-password page after login" do
-    user = users(:acme_trainer_three)
+  setup do
+    @pending_user = users(:acme_trainer_three)
+    @active_user = users(:acme_trainer_one)
+  end
 
-    post session_path, params: { email_address: user.email_address, password: "password" }
+  test "pending user is redirected to change-password page after login" do
+    post session_path, params: { email_address: @pending_user.email_address, password: "password" }
 
     assert_redirected_to edit_account_password_path
   end
 
   test "pending user login creates a session" do
-    user = users(:acme_trainer_three)
-
     assert_difference "Session.count" do
-      post session_path, params: { email_address: user.email_address, password: "password" }
+      post session_path, params: { email_address: @pending_user.email_address, password: "password" }
     end
   end
 
   test "pending user cannot navigate to other pages" do
-    user = users(:acme_trainer_three)
-    sign_in_as(user)
+    sign_in_as(@pending_user)
 
     get root_path
 
@@ -27,8 +27,7 @@ class ForcedPasswordChangeTest < ActionDispatch::IntegrationTest
   end
 
   test "pending user cannot navigate to account settings" do
-    user = users(:acme_trainer_three)
-    sign_in_as(user)
+    sign_in_as(@pending_user)
 
     get edit_account_settings_path
 
@@ -36,8 +35,7 @@ class ForcedPasswordChangeTest < ActionDispatch::IntegrationTest
   end
 
   test "pending user can access the change-password page" do
-    user = users(:acme_trainer_three)
-    sign_in_as(user)
+    sign_in_as(@pending_user)
 
     get edit_account_password_path
 
@@ -45,33 +43,30 @@ class ForcedPasswordChangeTest < ActionDispatch::IntegrationTest
   end
 
   test "submitting a valid password changes status to active and redirects to home" do
-    user = users(:acme_trainer_three)
-    sign_in_as(user)
+    sign_in_as(@pending_user)
 
     patch account_password_path, params: { user: { password: "newpassword123!", password_confirmation: "newpassword123!" } }
 
     assert_redirected_to master_trainings_path
     assert_equal I18n.t("account.passwords.update.success"), flash[:notice]
 
-    user.reload
-    assert user.active?
+    @pending_user.reload
+    assert @pending_user.active?
   end
 
   test "submitting mismatched passwords re-renders the form with errors" do
-    user = users(:acme_trainer_three)
-    sign_in_as(user)
+    sign_in_as(@pending_user)
 
     patch account_password_path, params: { user: { password: "newpassword123!", password_confirmation: "different!" } }
 
     assert_response :unprocessable_entity
 
-    user.reload
-    assert user.pending_password_change?
+    @pending_user.reload
+    assert @pending_user.pending_password_change?
   end
 
   test "active user is not redirected to change-password page" do
-    user = users(:acme_trainer_one)
-    sign_in_as(user)
+    sign_in_as(@active_user)
 
     get root_path
 
@@ -79,8 +74,7 @@ class ForcedPasswordChangeTest < ActionDispatch::IntegrationTest
   end
 
   test "active user cannot access change-password page" do
-    user = users(:acme_trainer_one)
-    sign_in_as(user)
+    sign_in_as(@active_user)
 
     get edit_account_password_path
 

--- a/test/system/account_trainers_test.rb
+++ b/test/system/account_trainers_test.rb
@@ -1,14 +1,14 @@
 require "application_system_test_case"
 
 class AccountTrainersTest < ApplicationSystemTestCase
-  test "account admin sees trainers listed with their status" do
-    account_admin = users(:acme_admin)
-
-    sign_in_via_ui account_admin
+  setup do
+    @account_admin = users(:acme_admin)
+    sign_in_via_ui @account_admin
     assert_current_path edit_account_settings_path
-
     click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+  end
 
+  test "account admin sees trainers listed with their status" do
     assert_text users(:acme_trainer_one).email_address
     assert_text users(:acme_trainer_two).email_address
     assert_text users(:acme_trainer_three).email_address
@@ -19,13 +19,7 @@ class AccountTrainersTest < ApplicationSystemTestCase
   end
 
   test "admin removes a trainer from the roster" do
-    account_admin = users(:acme_admin)
     trainer = users(:acme_trainer_one)
-
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
 
     assert_text trainer.email_address
     within("tr", text: trainer.email_address) do
@@ -39,13 +33,7 @@ class AccountTrainersTest < ApplicationSystemTestCase
   end
 
   test "admin deactivates an active trainer and reactivates them" do
-    account_admin = users(:acme_admin)
     trainer = users(:acme_trainer_one)
-
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
 
     assert_text trainer.email_address
     within("tr", text: trainer.email_address) do


### PR DESCRIPTION
### Helpers Extracted

- **`ForcedPasswordChangeTest` setup block** — eliminates 9 repeated fixture lookups (`users(:acme_trainer_three)` × 7, `users(:acme_trainer_one)` × 2) across 9 tests
- **`AccountTrainersIntegrationTest#assert_trainer_removed`** — private helper replacing 3 identical 6-line delete-and-assert blocks
- **`AccountTrainersTest` (system) setup block** — eliminates 4-line sign-in + navigate-to-roster sequence repeated in all 3 tests

### Before / After

#### `ForcedPasswordChangeTest` — fixture lookup duplication

```ruby
# Before (repeated 7 times across different tests)
test "pending user cannot navigate to other pages" do
  user = users(:acme_trainer_three)
  sign_in_as(user)
  ...
end

# After
setup do
  `@pending_user` = users(:acme_trainer_three)
  `@active_user` = users(:acme_trainer_one)
end

test "pending user cannot navigate to other pages" do
  sign_in_as(`@pending_user`)
  ...
end
```

#### `AccountTrainersIntegrationTest` — repeated assertion blocks

```ruby
# Before (3× identical pattern, only fixture name differs)
test "admin removes an active trainer" do
  sign_in_as(`@account_admin`)
  trainer = users(:acme_trainer_one)

  assert_difference "User.count", -1 do
    delete account_trainer_path(trainer)
  end
  assert_redirected_to account_trainers_path
  follow_redirect!
  assert_match trainer.email_address, flash[:notice]
  assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
end

# After
test "admin removes an active trainer" do
  sign_in_as(`@account_admin`)
  assert_trainer_removed(users(:acme_trainer_one))
end

private

def assert_trainer_removed(trainer)
  assert_difference "User.count", -1 do
    delete account_trainer_path(trainer)
  end
  assert_redirected_to account_trainers_path
  follow_redirect!
  assert_match trainer.email_address, flash[:notice]
  assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
end
```

#### `AccountTrainersTest` (system) — repeated navigation setup

```ruby
# Before (4 lines repeated in all 3 tests)
test "account admin sees trainers listed with their status" do
  account_admin = users(:acme_admin)
  sign_in_via_ui account_admin
  assert_current_path edit_account_settings_path
  click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
  ...
end

# After
setup do
  `@account_admin` = users(:acme_admin)
  sign_in_via_ui `@account_admin`
  assert_current_path edit_account_settings_path
  click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
end

test "account admin sees trainers listed with their status" do
  # test body only
end
```

### Files Changed

- `test/integration/forced_password_change_test.rb` — 9 fixture lookups removed via setup block
- `test/integration/account_trainers_test.rb` — 3 × 6-line assertion blocks replaced by `assert_trainer_removed` helper
- `test/system/account_trainers_test.rb` — 3 × 4-line sign-in/navigate sequences replaced by setup block

**References:** [§24990792277](https://github.com/jonaskay/rocket/actions/runs/24990792277)




> Generated by [Test Cleanup Agent](https://github.com/jonaskay/rocket/actions/runs/24990792277)
> - [x] expires <!-- gh-aw-expires: 2026-04-29T11:00:20.078Z --> on Apr 29, 2026, 11:00 AM UTC

<!-- gh-aw-agentic-workflow: Test Cleanup Agent, engine: copilot, id: 24990792277, workflow_id: test-cleanup-agent, run: https://github.com/jonaskay/rocket/actions/runs/24990792277 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: test-cleanup-agent -->