### PR TITLE
[test] Extract shared helpers to reduce test duplication

### DIFF
--- a/test/integration/account_trainers_test.rb
+++ b/test/integration/account_trainers_test.rb
@@ -46,45 +46,15 @@ class AccountTrainersIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "admin removes an active trainer" do
-    sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_one)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_removal_succeeds(users(:acme_trainer_one))
   end
 
   test "admin removes an inactive trainer" do
-    sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_two)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_removal_succeeds(users(:acme_trainer_two))
   end
 
   test "admin removes a pending trainer" do
-    sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_three)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_removal_succeeds(users(:acme_trainer_three))
   end
 
   test "admin fails to remove a trainer when destroy fails" do
@@ -126,5 +96,20 @@ class AccountTrainersIntegrationTest < ActionDispatch::IntegrationTest
 
     assert_response :not_found
     assert_equal original_attributes, other_trainer.reload.attributes
+  end
+
+  private
+
+  def assert_trainer_removal_succeeds(trainer)
+    sign_in_as(@account_admin)
+
+    assert_difference "User.count", -1 do
+      delete account_trainer_path(trainer)
+    end
+
+    assert_redirected_to account_trainers_path
+    follow_redirect!
+    assert_match trainer.email_address, flash[:notice]
+    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
   end
 end

--- a/test/integration/forced_password_change_test.rb
+++ b/test/integration/forced_password_change_test.rb
@@ -1,25 +1,24 @@
 require "test_helper"
 
 class ForcedPasswordChangeTest < ActionDispatch::IntegrationTest
-  test "pending user is redirected to change-password page after login" do
-    user = users(:acme_trainer_three)
+  setup do
+    @pending_user = users(:acme_trainer_three)
+  end
 
-    post session_path, params: { email_address: user.email_address, password: "password" }
+  test "pending user is redirected to change-password page after login" do
+    post session_path, params: { email_address: @pending_user.email_address, password: "password" }
 
     assert_redirected_to edit_account_password_path
   end
 
   test "pending user login creates a session" do
-    user = users(:acme_trainer_three)
-
     assert_difference "Session.count" do
-      post session_path, params: { email_address: user.email_address, password: "password" }
+      post session_path, params: { email_address: @pending_user.email_address, password: "password" }
     end
   end
 
   test "pending user cannot navigate to other pages" do
-    user = users(:acme_trainer_three)
-    sign_in_as(user)
+    sign_in_as(@pending_user)
 
     get root_path
 
@@ -27,8 +26,7 @@ class ForcedPasswordChangeTest < ActionDispatch::IntegrationTest
   end
 
   test "pending user cannot navigate to account settings" do
-    user = users(:acme_trainer_three)
-    sign_in_as(user)
+    sign_in_as(@pending_user)
 
     get edit_account_settings_path
 
@@ -36,8 +34,7 @@ class ForcedPasswordChangeTest < ActionDispatch::IntegrationTest
   end
 
   test "pending user can access the change-password page" do
-    user = users(:acme_trainer_three)
-    sign_in_as(user)
+    sign_in_as(@pending_user)
 
     get edit_account_password_path
 
@@ -45,28 +42,26 @@ class ForcedPasswordChangeTest < ActionDispatch::IntegrationTest
   end
 
   test "submitting a valid password changes status to active and redirects to home" do
-    user = users(:acme_trainer_three)
-    sign_in_as(user)
+    sign_in_as(@pending_user)
 
     patch account_password_path, params: { user: { password: "newpassword123!", password_confirmation: "newpassword123!" } }
 
     assert_redirected_to master_trainings_path
     assert_equal I18n.t("account.passwords.update.success"), flash[:notice]
 
-    user.reload
-    assert user.active?
+    @pending_user.reload
+    assert @pending_user.active?
   end
 
   test "submitting mismatched passwords re-renders the form with errors" do
-    user = users(:acme_trainer_three)
-    sign_in_as(user)
+    sign_in_as(@pending_user)
 
     patch account_password_path, params: { user: { password: "newpassword123!", password_confirmation: "different!" } }
 
     assert_response :unprocessable_entity
 
-    user.reload
-    assert user.pending_password_change?
+    @pending_user.reload
+    assert @pending_user.pending_password_change?
   end
 
   test "active user is not redirected to change-password page" do

--- a/test/system/account_trainers_test.rb
+++ b/test/system/account_trainers_test.rb
@@ -1,13 +1,12 @@
 require "application_system_test_case"
 
 class AccountTrainersTest < ApplicationSystemTestCase
+  setup do
+    @account_admin = users(:acme_admin)
+  end
+
   test "account admin sees trainers listed with their status" do
-    account_admin = users(:acme_admin)
-
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+    sign_in_and_visit_trainer_roster
 
     assert_text users(:acme_trainer_one).email_address
     assert_text users(:acme_trainer_two).email_address
@@ -19,13 +18,9 @@ class AccountTrainersTest < ApplicationSystemTestCase
   end
 
   test "admin removes a trainer from the roster" do
-    account_admin = users(:acme_admin)
     trainer = users(:acme_trainer_one)
 
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+    sign_in_and_visit_trainer_roster
 
     assert_text trainer.email_address
     within("tr", text: trainer.email_address) do
@@ -39,13 +34,9 @@ class AccountTrainersTest < ApplicationSystemTestCase
   end
 
   test "admin deactivates an active trainer and reactivates them" do
-    account_admin = users(:acme_admin)
     trainer = users(:acme_trainer_one)
 
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+    sign_in_and_visit_trainer_roster
 
     assert_text trainer.email_address
     within("tr", text: trainer.email_address) do
@@ -67,5 +58,13 @@ class AccountTrainersTest < ApplicationSystemTestCase
     within("tr", text: trainer.email_address) do
       assert_text "Active"
     end
+  end
+
+  private
+
+  def sign_in_and_visit_trainer_roster
+    sign_in_via_ui @account_admin
+    assert_current_path edit_account_settings_path
+    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
   end
 end


### PR DESCRIPTION
### Helpers Extracted

Three duplication patterns (each appearing 3+ times) were identified and eliminated:

#### 1. `AccountTrainersTest#sign_in_and_visit_trainer_roster` — system test
All three system tests in `account_trainers_test.rb` repeated the same 4-line block to sign in as the account admin and navigate to the Trainer Roster. A private helper plus a `setup` block replaces them.

#### 2. `AccountTrainersIntegrationTest#assert_trainer_removal_succeeds` — integration test
Three integration tests ("admin removes an active/inactive/pending trainer") were byte-for-byte identical except for the fixture used. A private helper that accepts the trainer as an argument collapses all three to single-line calls.

#### 3. `ForcedPasswordChangeTest` — setup block for `@pending_user`
7 out of 9 tests in `forced_password_change_test.rb` opened with `user = users(:acme_trainer_three)`. A `setup` block introduces `@pending_user` and removes the repeated lookup entirely.

---

### Before / After

```ruby
# Before — repeated 3 times in account_trainers_test.rb (integration)
test "admin removes an active trainer" do
  sign_in_as(`@account_admin`)
  trainer = users(:acme_trainer_one)
  assert_difference "User.count", -1 do
    delete account_trainer_path(trainer)
  end
  assert_redirected_to account_trainers_path
  follow_redirect!
  assert_match trainer.email_address, flash[:notice]
  assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
end

# After
test "admin removes an active trainer" do
  assert_trainer_removal_succeeds(users(:acme_trainer_one))
end
```

---

### Files Changed

| File | Change |
|---|---|
| `test/system/account_trainers_test.rb` | Added `setup` block + private `sign_in_and_visit_trainer_roster`; 3 occurrences replaced |
| `test/integration/account_trainers_test.rb` | Added private `assert_trainer_removal_succeeds`; 3 near-identical test bodies collapsed to 1 line each |
| `test/integration/forced_password_change_test.rb` | Added `setup` block with `@pending_user`; 7 repeated fixture lookups removed |

**Net change**: −69 lines added, +48 lines (21 fewer lines of test code overall).

**References:** [§25314961113](https://github.com/jonaskay/rocket/actions/runs/25314961113)




> Generated by [Test Cleanup Agent](https://github.com/jonaskay/rocket/actions/runs/25314961113)
> - [x] expires <!-- gh-aw-expires: 2026-05-06T11:01:28.580Z --> on May 6, 2026, 11:01 AM UTC

<!-- gh-aw-agentic-workflow: Test Cleanup Agent, engine: copilot, id: 25314961113, workflow_id: test-cleanup-agent, run: https://github.com/jonaskay/rocket/actions/runs/25314961113 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: test-cleanup-agent -->