### PR TITLE
[docs] Update glossary - weekly full scan

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -16,9 +16,11 @@ Important domain terms for the Rocket training platform.
 
 **Exercise Snapshot** — An immutable HTML copy of an exercise's rich text body captured at the time a training session is generated. Stored on the `exercise_snapshots` table as sanitized HTML.
 
-**Forced Password Change** — A security gate applied to trainers with `status: pending_password_change`. When such a trainer logs in, they are immediately redirected to `/account/password/edit` and cannot navigate to any other page until they set a new password. After submitting a valid password, their status is automatically transitioned to `active` and they are redirected to the home page.
+**Forced Password Change** — A security gate applied to trainers with `status: pending_password_change`. When such a trainer logs in, they are immediately redirected to `/account/password/edit` and cannot navigate to any other page until they set a new password. After submitting a valid password, their status is automatically transitioned to `active` and they are redirected to the Master Trainings Dashboard.
 
 **Invitation Flow** — The process by which an account admin adds a new trainer to their organization. The system creates the trainer's account with `status: pending_password_change` and sends an invitation email containing a signed, time-limited link. When the trainer follows the link and sets their password, their status is automatically transitioned to `active`, allowing them to log in immediately.
+
+**Master Trainings Dashboard** — The trainer home page at `/master_trainings` that lists all master trainings belonging to the trainer's client account, ordered by most recently updated. Trainers are redirected here after sign-in and after completing a forced password change. Access is restricted to trainers; account admins and unauthenticated users are redirected away.
 
 **Master Training** — A reusable training template created and owned by a trainer. Contains slides, prerequisite assets, and exercises. Multiple training sessions can be generated from a single master training at different points in time.
 


### PR DESCRIPTION
## Glossary Updates - 2026-05-04

### Scan Type
- [ ] Incremental (daily - last 24 hours)
- [x] Full scan (weekly - last 7 days)

> **Note:** No new commits found since 2026-03-27. However, prior glossary PR #105 (2026-04-24 daily scan) was closed on 2026-04-26 without being merged, leaving two pending changes unapplied. This PR re-applies those changes.

### Terms Added
- **Master Trainings Dashboard**: New page at `/master_trainings` introduced in PR #69. Serves as the trainer home screen after sign-in and after a forced password change.

### Terms Updated
- **Forced Password Change**: Corrected redirect destination from "home page" to "Master Trainings Dashboard", reflecting commit `331fb15` which switched the post-password-change redirect from `root_path` to `master_trainings_path`.

### Changes Analyzed
- Reviewed 0 new commits (no activity since 2026-03-27)
- Prior PR #105 was found closed without merging — its changes are re-applied here

### Related Changes
- Commit `76c024a`: Add master trainings dashboard for trainers (issue #62)
- Commit `331fb15`: Fix trainer removal FK violation and password change redirect
- PR #69: Add master trainings dashboard for trainers
- PR #105: Prior glossary PR (closed without merging on 2026-04-26)

### Notes
All repository commits through 2026-03-27 have been processed. No new terminology was introduced since the last scan. Cache will be updated to reflect this weekly scan.




> Generated by [Glossary Maintainer](https://github.com/jonaskay/rocket/actions/runs/25317198657)
> - [x] expires <!-- gh-aw-expires: 2026-05-06T11:52:38.579Z --> on May 6, 2026, 11:52 AM UTC

<!-- gh-aw-agentic-workflow: Glossary Maintainer, engine: copilot, id: 25317198657, workflow_id: glossary-maintainer, run: https://github.com/jonaskay/rocket/actions/runs/25317198657 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: glossary-maintainer -->