### PR TITLE
[test] Extract shared helpers to reduce test duplication

### DIFF
--- a/test/integration/account_trainers_test.rb
+++ b/test/integration/account_trainers_test.rb
@@ -47,44 +47,17 @@ class AccountTrainersIntegrationTest < ActionDispatch::IntegrationTest
 
   test "admin removes an active trainer" do
     sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_one)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_removed(users(:acme_trainer_one))
   end
 
   test "admin removes an inactive trainer" do
     sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_two)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_removed(users(:acme_trainer_two))
   end
 
   test "admin removes a pending trainer" do
     sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_three)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_removed(users(:acme_trainer_three))
   end
 
   test "admin fails to remove a trainer when destroy fails" do
@@ -126,5 +99,18 @@ class AccountTrainersIntegrationTest < ActionDispatch::IntegrationTest
 
     assert_response :not_found
     assert_equal original_attributes, other_trainer.reload.attributes
+  end
+
+  private
+
+  def assert_trainer_removed(trainer)
+    assert_difference "User.count", -1 do
+      delete account_trainer_path(trainer)
+    end
+
+    assert_redirected_to account_trainers_path
+    follow_redirect!
+    assert_match trainer.email_address, flash[:notice]
+    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
   end
 end

--- a/test/integration/admin_clients_test.rb
+++ b/test/integration/admin_clients_test.rb
@@ -86,44 +86,24 @@ class AdminClientsIntegrationTest < ActionDispatch::IntegrationTest
 
   test "creation fails when client name is blank" do
     sign_in_as(@admin)
-
-    assert_no_difference "Client.count" do
-      post admin_clients_path, params: valid_client_params(name: "")
-    end
-
-    assert_response :unprocessable_entity
+    assert_client_creation_fails(valid_client_params(name: ""))
     assert_select ".text-red-700", text: /can't be blank/
   end
 
   test "creation fails when admin email is blank" do
     sign_in_as(@admin)
-
-    assert_no_difference [ "Client.count", "User.count" ] do
-      post admin_clients_path, params: valid_client_params(user: { email_address: "" })
-    end
-
-    assert_response :unprocessable_entity
+    assert_client_creation_fails(valid_client_params(user: { email_address: "" }))
     assert_select ".text-red-700", text: /can't be blank/
   end
 
   test "creation fails when admin email is already taken" do
     sign_in_as(@admin)
-
-    assert_no_difference "Client.count" do
-      post admin_clients_path, params: valid_client_params(user: { email_address: users(:acme_admin).email_address })
-    end
-
-    assert_response :unprocessable_entity
+    assert_client_creation_fails(valid_client_params(user: { email_address: users(:acme_admin).email_address }))
   end
 
   test "creation fails when password confirmation does not match" do
     sign_in_as(@admin)
-
-    assert_no_difference [ "Client.count", "User.count" ] do
-      post admin_clients_path, params: valid_client_params(user: { password_confirmation: "wrongpassword" })
-    end
-
-    assert_response :unprocessable_entity
+    assert_client_creation_fails(valid_client_params(user: { password_confirmation: "wrongpassword" }))
   end
 
   test "show page renders client name and user list" do
@@ -184,5 +164,13 @@ class AdminClientsIntegrationTest < ActionDispatch::IntegrationTest
     }.merge(user)
 
     { client: { name: name, users_attributes: { "0" => user_attrs } } }
+  end
+
+  def assert_client_creation_fails(params)
+    assert_no_difference [ "Client.count", "User.count" ] do
+      post admin_clients_path, params: params
+    end
+
+    assert_response :unprocessable_entity
   end
 end

--- a/test/integration/forced_password_change_test.rb
+++ b/test/integration/forced_password_change_test.rb
@@ -1,25 +1,25 @@
 require "test_helper"
 
 class ForcedPasswordChangeTest < ActionDispatch::IntegrationTest
-  test "pending user is redirected to change-password page after login" do
-    user = users(:acme_trainer_three)
+  setup do
+    @pending_user = users(:acme_trainer_three)
+    @active_user = users(:acme_trainer_one)
+  end
 
-    post session_path, params: { email_address: user.email_address, password: "password" }
+  test "pending user is redirected to change-password page after login" do
+    post session_path, params: { email_address: @pending_user.email_address, password: "password" }
 
     assert_redirected_to edit_account_password_path
   end
 
   test "pending user login creates a session" do
-    user = users(:acme_trainer_three)
-
     assert_difference "Session.count" do
-      post session_path, params: { email_address: user.email_address, password: "password" }
+      post session_path, params: { email_address: @pending_user.email_address, password: "password" }
     end
   end
 
   test "pending user cannot navigate to other pages" do
-    user = users(:acme_trainer_three)
-    sign_in_as(user)
+    sign_in_as(@pending_user)
 
     get root_path
 
@@ -27,8 +27,7 @@ class ForcedPasswordChangeTest < ActionDispatch::IntegrationTest
   end
 
   test "pending user cannot navigate to account settings" do
-    user = users(:acme_trainer_three)
-    sign_in_as(user)
+    sign_in_as(@pending_user)
 
     get edit_account_settings_path
 
@@ -36,8 +35,7 @@ class ForcedPasswordChangeTest < ActionDispatch::IntegrationTest
   end
 
   test "pending user can access the change-password page" do
-    user = users(:acme_trainer_three)
-    sign_in_as(user)
+    sign_in_as(@pending_user)
 
     get edit_account_password_path
 
@@ -45,33 +43,30 @@ class ForcedPasswordChangeTest < ActionDispatch::IntegrationTest
   end
 
   test "submitting a valid password changes status to active and redirects to home" do
-    user = users(:acme_trainer_three)
-    sign_in_as(user)
+    sign_in_as(@pending_user)
 
     patch account_password_path, params: { user: { password: "newpassword123!", password_confirmation: "newpassword123!" } }
 
     assert_redirected_to master_trainings_path
     assert_equal I18n.t("account.passwords.update.success"), flash[:notice]
 
-    user.reload
-    assert user.active?
+    @pending_user.reload
+    assert @pending_user.active?
   end
 
   test "submitting mismatched passwords re-renders the form with errors" do
-    user = users(:acme_trainer_three)
-    sign_in_as(user)
+    sign_in_as(@pending_user)
 
     patch account_password_path, params: { user: { password: "newpassword123!", password_confirmation: "different!" } }
 
     assert_response :unprocessable_entity
 
-    user.reload
-    assert user.pending_password_change?
+    @pending_user.reload
+    assert @pending_user.pending_password_change?
   end
 
   test "active user is not redirected to change-password page" do
-    user = users(:acme_trainer_one)
-    sign_in_as(user)
+    sign_in_as(@active_user)
 
     get root_path
 
@@ -79,8 +74,7 @@ class ForcedPasswordChangeTest < ActionDispatch::IntegrationTest
   end
 
   test "active user cannot access change-password page" do
-    user = users(:acme_trainer_one)
-    sign_in_as(user)
+    sign_in_as(@active_user)
 
     get edit_account_password_path
 


### PR DESCRIPTION
### Test Cleanup

Scanned all integration and system test files for repeated code blocks (≥3 occurrences). Extracted three helpers to eliminate 32 lines of duplicated boilerplate.

---

### Helpers Extracted

- **`AccountTrainersIntegrationTest#assert_trainer_removed(trainer)`** — replaces 3 copy-pasted delete-and-verify blocks across the "admin removes active/inactive/pending trainer" tests
- **`AdminClientsIntegrationTest#assert_client_creation_fails(params)`** — replaces 4 identical `assert_no_difference + post + assert_response :unprocessable_entity` blocks, mirroring the existing `assert_invitation_fails` pattern in `account_trainer_invite_test.rb`
- **`ForcedPasswordChangeTest` setup block** — adds `@pending_user` / `@active_user` instance variables to replace 8 repeated `user = users(:fixture_name)` assignments

---

### Before / After

````ruby
# Before — repeated 3 times with only the fixture name changing
test "admin removes an active trainer" do
  sign_in_as(`@account_admin`)
  trainer = users(:acme_trainer_one)

  assert_difference "User.count", -1 do
    delete account_trainer_path(trainer)
  end

  assert_redirected_to account_trainers_path
  follow_redirect!
  assert_match trainer.email_address, flash[:notice]
  assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
end

# After
test "admin removes an active trainer" do
  sign_in_as(`@account_admin`)
  assert_trainer_removed(users(:acme_trainer_one))
end
````

---

### Files Changed

- `test/integration/account_trainers_test.rb` — 3 removal blocks replaced with `assert_trainer_removed`; private helper added
- `test/integration/admin_clients_test.rb` — 4 creation-failure blocks replaced with `assert_client_creation_fails`; private helper added
- `test/integration/forced_password_change_test.rb` — 8 repeated fixture lookups replaced via `setup` block

**Net change: 46 insertions, 78 deletions (−32 lines)**




> Generated by [Test Cleanup Agent](https://github.com/jonaskay/rocket/actions/runs/25668555611)
> - [x] expires <!-- gh-aw-expires: 2026-05-13T12:05:16.470Z --> on May 13, 2026, 12:05 PM UTC

<!-- gh-aw-agentic-workflow: Test Cleanup Agent, engine: copilot, id: 25668555611, workflow_id: test-cleanup-agent, run: https://github.com/jonaskay/rocket/actions/runs/25668555611 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: test-cleanup-agent -->