### PR TITLE
[docs] Update glossary - daily scan

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -16,11 +16,13 @@ Important domain terms for the Rocket training platform.
 
 **Exercise Snapshot** — An immutable HTML copy of an exercise's rich text body captured at the time a training session is generated. Stored on the `exercise_snapshots` table as sanitized HTML.
 
-**Forced Password Change** — A security gate applied to trainers with `status: pending_password_change`. When such a trainer logs in, they are immediately redirected to `/account/password/edit` and cannot navigate to any other page until they set a new password. After submitting a valid password, their status is automatically transitioned to `active` and they are redirected to the home page.
+**Forced Password Change** — A security gate applied to trainers with `status: pending_password_change`. When such a trainer logs in, they are immediately redirected to `/account/password/edit` and cannot navigate to any other page until they set a new password. After submitting a valid password, their status is automatically transitioned to `active` and they are redirected to the Master Trainings Dashboard.
 
 **Invitation Flow** — The process by which an account admin adds a new trainer to their organization. The system creates the trainer's account with `status: pending_password_change` and sends an invitation email containing a signed, time-limited link. When the trainer follows the link and sets their password, their status is automatically transitioned to `active`, allowing them to log in immediately.
 
 **Master Training** — A reusable training template created and owned by a trainer. Contains slides, prerequisite assets, and exercises. Multiple training sessions can be generated from a single master training at different points in time.
+
+**Master Trainings Dashboard** — The page at `/master_trainings` where trainers can view all master trainings for their account, displayed in a table ordered by most recently updated. Trainers are redirected here after login. Access is restricted to trainers only; account admins and unauthenticated users are redirected away. Trainers see only their own account's trainings.
 
 **Password Gate** — The password entry page shown at `/s/:slug/unlock` when a training session is password-protected. Participants must submit the correct password before the session content is revealed.
 


### PR DESCRIPTION
## Glossary Updates - 2026-05-11

### Scan Type
- [x] Incremental (daily - last 24 hours)
- [ ] Full scan (weekly - last 7 days)

> **Note**: Today is Monday, which normally triggers a full weekly scan. However, no new commits have been made since the last processed scan (most recent commit: `2117c5a` from 2026-03-27). The changes in this PR are carry-overs from a previous glossary PR that was created on 2026-05-04 but was closed without merging.

### Terms Added
- **Master Trainings Dashboard**: The `/master_trainings` page for trainers was added in commit `76c024ae` but was never reflected in the glossary due to a prior PR being closed without merging.

### Terms Updated
- **Forced Password Change**: Updated the post-password-change redirect description from "home page" to "Master Trainings Dashboard", reflecting the change made in commit `331fb15d` (redirect to `master_trainings_path` instead of `root_path`).

### Changes Analyzed
- Reviewed 20 most recent commits (no new commits since 2026-03-27)
- Found 0 open glossary PRs (previous scan PR was closed without merging)
- Applied 2 pending glossary updates

### Related Changes
- Commit `76c024ae`: Add master trainings dashboard for trainers (issue #62)
- Commit `331fb15d`: Fix trainer removal FK violation and password change redirect
- Commit `98d5564f`: Merge PR #69 - Add master trainings dashboard for trainers

### Notes
The cache showed a previous PR was created on 2026-05-04 with these same changes, but it was never merged. This PR re-applies those changes.




> Generated by [Glossary Maintainer](https://github.com/jonaskay/rocket/actions/runs/25670568576)
> - [x] expires <!-- gh-aw-expires: 2026-05-13T12:43:39.727Z --> on May 13, 2026, 12:43 PM UTC

<!-- gh-aw-agentic-workflow: Glossary Maintainer, engine: copilot, id: 25670568576, workflow_id: glossary-maintainer, run: https://github.com/jonaskay/rocket/actions/runs/25670568576 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: glossary-maintainer -->