### PR TITLE
[docs] Update glossary - daily scan

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -16,11 +16,13 @@ Important domain terms for the Rocket training platform.
 
 **Exercise Snapshot** — An immutable HTML copy of an exercise's rich text body captured at the time a training session is generated. Stored on the `exercise_snapshots` table as sanitized HTML.
 
-**Forced Password Change** — A security gate applied to trainers with `status: pending_password_change`. When such a trainer logs in, they are immediately redirected to `/account/password/edit` and cannot navigate to any other page until they set a new password. After submitting a valid password, their status is automatically transitioned to `active` and they are redirected to the home page.
+**Forced Password Change** — A security gate applied to trainers with `status: pending_password_change`. When such a trainer logs in, they are immediately redirected to `/account/password/edit` and cannot navigate to any other page until they set a new password. After submitting a valid password, their status is automatically transitioned to `active` and they are redirected to the Master Trainings Dashboard.
 
 **Invitation Flow** — The process by which an account admin adds a new trainer to their organization. The system creates the trainer's account with `status: pending_password_change` and sends an invitation email containing a signed, time-limited link. When the trainer follows the link and sets their password, their status is automatically transitioned to `active`, allowing them to log in immediately.
 
 **Master Training** — A reusable training template created and owned by a trainer. Contains slides, prerequisite assets, and exercises. Multiple training sessions can be generated from a single master training at different points in time.
+
+**Master Trainings Dashboard** — The page at `/master_trainings` where trainers can view all master trainings belonging to their account, listed in a table ordered by most recently updated. Access is restricted to trainers only; account admins and unauthenticated users are redirected away. Trainers are redirected here after login.
 
 **Password Gate** — The password entry page shown at `/s/:slug/unlock` when a training session is password-protected. Participants must submit the correct password before the session content is revealed.
 


### PR DESCRIPTION
## Glossary Updates - 2026-05-15

### Scan Type
- [x] Incremental (daily - last 24 hours)
- [ ] Full scan (weekly - last 7 days)

> **Note**: No new commits since the last processed commit (`2117c5a` from 2026-03-27). This PR re-applies two pending glossary changes from prior PRs (#111, #115) that were closed without being merged.

### Terms Added
- **Master Trainings Dashboard**: The `/master_trainings` page where trainers view all their master trainings, introduced in commit `76c024ae` (issue #62).

### Terms Updated
- **Forced Password Change**: Updated post-password-change redirect destination from "home page" to "Master Trainings Dashboard", reflecting the change in commit `331fb15d`.

### Changes Analyzed
- Reviewed 20 most recent commits (no new commits since 2026-03-27)
- Found PR #115 (2026-05-11) closed without merging — re-applied its changes

### Related Changes
- Commit `76c024ae`: Add master trainings dashboard for trainers (issue #62)
- Commit `331fb15d`: Fix trainer removal FK violation and password change redirect
- PR #69: Add master trainings dashboard for trainers

### Notes
These changes have been proposed in glossary PRs #111 and #115 previously, but both were closed without merging. This PR re-applies the same updates.

> Generated by [Glossary Maintainer](https://github.com/jonaskay/rocket/actions/runs/25916462683)




> Generated by [Glossary Maintainer](https://github.com/jonaskay/rocket/actions/runs/25916462683)
> - [x] expires <!-- gh-aw-expires: 2026-05-17T12:03:56.421Z --> on May 17, 2026, 12:03 PM UTC

<!-- gh-aw-agentic-workflow: Glossary Maintainer, engine: copilot, id: 25916462683, workflow_id: glossary-maintainer, run: https://github.com/jonaskay/rocket/actions/runs/25916462683 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: glossary-maintainer -->