### PR TITLE
[test] Extract shared helpers to reduce test duplication

### DIFF
--- a/test/support/capybara_helpers.rb
+++ b/test/support/capybara_helpers.rb
@@ -28,4 +28,10 @@ module CapybaraHelpers
   def sign_out_via_ui
     click_button_and_confirm "Sign out", title: I18n.t("sessions.new.title")
   end
+
+  def visit_trainer_roster_as(user)
+    sign_in_via_ui user
+    assert_current_path edit_account_settings_path
+    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+  end
 end

--- a/test/system/account_trainers_test.rb
+++ b/test/system/account_trainers_test.rb
@@ -2,12 +2,7 @@ require "application_system_test_case"
 
 class AccountTrainersTest < ApplicationSystemTestCase
   test "account admin sees trainers listed with their status" do
-    account_admin = users(:acme_admin)
-
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+    visit_trainer_roster_as users(:acme_admin)
 
     assert_text users(:acme_trainer_one).email_address
     assert_text users(:acme_trainer_two).email_address
@@ -19,13 +14,9 @@ class AccountTrainersTest < ApplicationSystemTestCase
   end
 
   test "admin removes a trainer from the roster" do
-    account_admin = users(:acme_admin)
     trainer = users(:acme_trainer_one)
 
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+    visit_trainer_roster_as users(:acme_admin)
 
     assert_text trainer.email_address
     within("tr", text: trainer.email_address) do
@@ -39,13 +30,9 @@ class AccountTrainersTest < ApplicationSystemTestCase
   end
 
   test "admin deactivates an active trainer and reactivates them" do
-    account_admin = users(:acme_admin)
     trainer = users(:acme_trainer_one)
 
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+    visit_trainer_roster_as users(:acme_admin)
 
     assert_text trainer.email_address
     within("tr", text: trainer.email_address) do


### PR DESCRIPTION
### Helpers Extracted

- **`CapybaraHelpers#visit_trainer_roster_as(user)`** — replaces 3 identical 4-line blocks across `test/system/account_trainers_test.rb`

### Before / After

```ruby
# Before (repeated in all 3 tests in AccountTrainersTest):
account_admin = users(:acme_admin)

sign_in_via_ui account_admin
assert_current_path edit_account_settings_path

click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")

# After:
visit_trainer_roster_as users(:acme_admin)
```

The new helper lives in `test/support/capybara_helpers.rb` (already included in `ApplicationSystemTestCase`):

```ruby
def visit_trainer_roster_as(user)
  sign_in_via_ui user
  assert_current_path edit_account_settings_path
  click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
end
```

### Files Changed
- `test/support/capybara_helpers.rb` — new helper added
- `test/system/account_trainers_test.rb` — 3 occurrences replaced (-16 lines, +3 lines)

### Patterns Considered but Skipped
The following patterns appear fewer than 3 times and were not extracted:
- `post account_trainers_path` with same user params — 2×  in `account_trainer_invite_test.rb` (integration)
- Trainer Roster → Invite Trainer navigation — 2× in `account_trainer_invite_test.rb` (system)
- `sign_in_as(`@admin`); get admin_client_path; assert_response :success` — 2× in `admin_clients_test.rb` (integration)

**References:** [§26033012536](https://github.com/jonaskay/rocket/actions/runs/26033012536)




> Generated by [Test Cleanup Agent](https://github.com/jonaskay/rocket/actions/runs/26033012536)
> - [x] expires <!-- gh-aw-expires: 2026-05-20T12:28:49.862Z --> on May 20, 2026, 12:28 PM UTC

<!-- gh-aw-agentic-workflow: Test Cleanup Agent, engine: copilot, id: 26033012536, workflow_id: test-cleanup-agent, run: https://github.com/jonaskay/rocket/actions/runs/26033012536 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: test-cleanup-agent -->