### PR TITLE
[docs] Update glossary - weekly full scan

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -16,11 +16,13 @@ Important domain terms for the Rocket training platform.
 
 **Exercise Snapshot** — An immutable HTML copy of an exercise's rich text body captured at the time a training session is generated. Stored on the `exercise_snapshots` table as sanitized HTML.
 
-**Forced Password Change** — A security gate applied to trainers with `status: pending_password_change`. When such a trainer logs in, they are immediately redirected to `/account/password/edit` and cannot navigate to any other page until they set a new password. After submitting a valid password, their status is automatically transitioned to `active` and they are redirected to the home page.
+**Forced Password Change** — A security gate applied to trainers with `status: pending_password_change`. When such a trainer logs in, they are immediately redirected to `/account/password/edit` and cannot navigate to any other page until they set a new password. After submitting a valid password, their status is automatically transitioned to `active` and they are redirected to the master trainings dashboard.
 
 **Invitation Flow** — The process by which an account admin adds a new trainer to their organization. The system creates the trainer's account with `status: pending_password_change` and sends an invitation email containing a signed, time-limited link. When the trainer follows the link and sets their password, their status is automatically transitioned to `active`, allowing them to log in immediately.
 
 **Master Training** — A reusable training template created and owned by a trainer. Contains slides, prerequisite assets, and exercises. Multiple training sessions can be generated from a single master training at different points in time.
+
+**Master Trainings Dashboard** — The trainer landing page at `/master_trainings` that lists all master trainings belonging to the trainer's client account, sorted by most recently updated. Accessible only to trainers (account admins and unauthenticated users are redirected away). Serves as the default redirect destination after a trainer logs in or completes a forced password change.
 
 **Password Gate** — The password entry page shown at `/s/:slug/unlock` when a training session is password-protected. Participants must submit the correct password before the session content is revealed.
 


### PR DESCRIPTION
## Glossary Updates - 2026-05-18

### Scan Type
- [ ] Incremental (daily - last 24 hours)
- [x] Full scan (weekly - last 7 days)

> Note: No commits occurred in the last 7 days (most recent commit was 2026-03-27). Analyzed all recent commits from the past several weeks to ensure glossary accuracy.

### Terms Added
- **Master Trainings Dashboard**: New trainer landing page at `/master_trainings` introduced in commit 76c024ae (PR #69 - Add master trainings dashboard for trainers).

### Terms Updated
- **Forced Password Change**: Updated redirect destination from "home page" to "master trainings dashboard" following commit 331fb15d, which changed the post-password-change redirect from `root_path` to `master_trainings_path`.

### Changes Analyzed
- Reviewed commits from March 2026 (6 key commits analyzed)
- Analyzed 1 merged PR (#69)

### Related Changes
- Commit `76c024ae`: Add master trainings dashboard for trainers (issue #62)
- Commit `331fb15d`: Fix trainer removal FK violation and password change redirect
- PR #69: Add master trainings dashboard for trainers

### Notes
No cache existed prior to this run. Cache has been initialized for future incremental scans.




> Generated by [Glossary Maintainer](https://github.com/jonaskay/rocket/actions/runs/26037356079)
> - [x] expires <!-- gh-aw-expires: 2026-05-20T13:49:35.921Z --> on May 20, 2026, 1:49 PM UTC

<!-- gh-aw-agentic-workflow: Glossary Maintainer, engine: copilot, id: 26037356079, workflow_id: glossary-maintainer, run: https://github.com/jonaskay/rocket/actions/runs/26037356079 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: glossary-maintainer -->