### PR TITLE
[test] Extract shared helpers to reduce test duplication

### DIFF
--- a/test/integration/account_trainers_test.rb
+++ b/test/integration/account_trainers_test.rb
@@ -47,44 +47,17 @@ class AccountTrainersIntegrationTest < ActionDispatch::IntegrationTest
 
   test "admin removes an active trainer" do
     sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_one)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_removed(users(:acme_trainer_one))
   end
 
   test "admin removes an inactive trainer" do
     sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_two)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_removed(users(:acme_trainer_two))
   end
 
   test "admin removes a pending trainer" do
     sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_three)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_removed(users(:acme_trainer_three))
   end
 
   test "admin fails to remove a trainer when destroy fails" do
@@ -126,5 +99,18 @@ class AccountTrainersIntegrationTest < ActionDispatch::IntegrationTest
 
     assert_response :not_found
     assert_equal original_attributes, other_trainer.reload.attributes
+  end
+
+  private
+
+  def assert_trainer_removed(trainer)
+    assert_difference "User.count", -1 do
+      delete account_trainer_path(trainer)
+    end
+
+    assert_redirected_to account_trainers_path
+    follow_redirect!
+    assert_match trainer.email_address, flash[:notice]
+    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
   end
 end

--- a/test/integration/master_trainings_test.rb
+++ b/test/integration/master_trainings_test.rb
@@ -43,8 +43,7 @@ class MasterTrainingsIntegrationTest < ActionDispatch::IntegrationTest
 
     get master_trainings_path
 
-    assert_redirected_to root_path
-    assert_equal I18n.t("master_trainings.unauthorized"), flash[:alert]
+    assert_master_training_unauthorized
   end
 
   test "super admin cannot access the edit action" do
@@ -53,8 +52,7 @@ class MasterTrainingsIntegrationTest < ActionDispatch::IntegrationTest
 
     get edit_master_training_path(training)
 
-    assert_redirected_to root_path
-    assert_equal I18n.t("master_trainings.unauthorized"), flash[:alert]
+    assert_master_training_unauthorized
   end
 
   test "super admin cannot access the update action" do
@@ -65,8 +63,7 @@ class MasterTrainingsIntegrationTest < ActionDispatch::IntegrationTest
       master_training: { title: "Hijacked", description: "" }
     }
 
-    assert_redirected_to root_path
-    assert_equal I18n.t("master_trainings.unauthorized"), flash[:alert]
+    assert_master_training_unauthorized
   end
 
   test "client admin cannot access the master trainings dashboard" do
@@ -74,8 +71,7 @@ class MasterTrainingsIntegrationTest < ActionDispatch::IntegrationTest
 
     get master_trainings_path
 
-    assert_redirected_to root_path
-    assert_equal I18n.t("master_trainings.unauthorized"), flash[:alert]
+    assert_master_training_unauthorized
   end
 
   test "client admin cannot access the edit action" do
@@ -84,8 +80,7 @@ class MasterTrainingsIntegrationTest < ActionDispatch::IntegrationTest
 
     get edit_master_training_path(training)
 
-    assert_redirected_to root_path
-    assert_equal I18n.t("master_trainings.unauthorized"), flash[:alert]
+    assert_master_training_unauthorized
   end
 
   test "client admin cannot access the update action" do
@@ -96,8 +91,7 @@ class MasterTrainingsIntegrationTest < ActionDispatch::IntegrationTest
       master_training: { title: "Hijacked", description: "" }
     }
 
-    assert_redirected_to root_path
-    assert_equal I18n.t("master_trainings.unauthorized"), flash[:alert]
+    assert_master_training_unauthorized
   end
 
   test "unauthenticated user is redirected to sign in" do
@@ -201,5 +195,12 @@ class MasterTrainingsIntegrationTest < ActionDispatch::IntegrationTest
     }
 
     assert_response :not_found
+  end
+
+  private
+
+  def assert_master_training_unauthorized
+    assert_redirected_to root_path
+    assert_equal I18n.t("master_trainings.unauthorized"), flash[:alert]
   end
 end

--- a/test/system/account_trainers_test.rb
+++ b/test/system/account_trainers_test.rb
@@ -4,10 +4,7 @@ class AccountTrainersTest < ApplicationSystemTestCase
   test "account admin sees trainers listed with their status" do
     account_admin = users(:acme_admin)
 
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+    navigate_to_trainer_roster(account_admin)
 
     assert_text users(:acme_trainer_one).email_address
     assert_text users(:acme_trainer_two).email_address
@@ -22,10 +19,7 @@ class AccountTrainersTest < ApplicationSystemTestCase
     account_admin = users(:acme_admin)
     trainer = users(:acme_trainer_one)
 
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+    navigate_to_trainer_roster(account_admin)
 
     assert_text trainer.email_address
     within("tr", text: trainer.email_address) do
@@ -42,10 +36,7 @@ class AccountTrainersTest < ApplicationSystemTestCase
     account_admin = users(:acme_admin)
     trainer = users(:acme_trainer_one)
 
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+    navigate_to_trainer_roster(account_admin)
 
     assert_text trainer.email_address
     within("tr", text: trainer.email_address) do
@@ -67,5 +58,13 @@ class AccountTrainersTest < ApplicationSystemTestCase
     within("tr", text: trainer.email_address) do
       assert_text "Active"
     end
+  end
+
+  private
+
+  def navigate_to_trainer_roster(account_admin)
+    sign_in_via_ui account_admin
+    assert_current_path edit_account_settings_path
+    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
   end
 end


### PR DESCRIPTION
## Test Cleanup

Reduces duplication by extracting three private helper methods from repeated code blocks across integration and system tests.

### Helpers Extracted

- **`AccountTrainersIntegrationTest#assert_trainer_removed(trainer)`** — replaces 3 identical 8-line blocks across the "admin removes active/inactive/pending trainer" tests
- **`MasterTrainingsIntegrationTest#assert_master_training_unauthorized`** — replaces 6 identical 2-line assertion pairs across the "super admin / client admin cannot access X" tests
- **`AccountTrainersTest#navigate_to_trainer_roster(account_admin)`** — replaces 3 identical 3-line sign-in-and-navigate sequences in system tests

### Before / After

```ruby
# Before (repeated 3 times in account_trainers_test.rb)
test "admin removes an active trainer" do
  sign_in_as(`@account_admin`)
  trainer = users(:acme_trainer_one)

  assert_difference "User.count", -1 do
    delete account_trainer_path(trainer)
  end

  assert_redirected_to account_trainers_path
  follow_redirect!
  assert_match trainer.email_address, flash[:notice]
  assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
end

# After
test "admin removes an active trainer" do
  sign_in_as(`@account_admin`)
  assert_trainer_removed(users(:acme_trainer_one))
end
```

```ruby
# Before (repeated 6 times in master_trainings_test.rb)
assert_redirected_to root_path
assert_equal I18n.t("master_trainings.unauthorized"), flash[:alert]

# After
assert_master_training_unauthorized
```

```ruby
# Before (repeated 3 times in system/account_trainers_test.rb)
sign_in_via_ui account_admin
assert_current_path edit_account_settings_path
click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")

# After
navigate_to_trainer_roster(account_admin)
```

### Files Changed

- `test/integration/account_trainers_test.rb` — 3 trainer removal tests collapsed to helper calls
- `test/integration/master_trainings_test.rb` — 6 unauthorized assertion pairs replaced
- `test/system/account_trainers_test.rb` — 3 sign-in-and-navigate sequences replaced

**Net result:** 3 files changed, 40 insertions(+), 54 deletions(−) — 14 fewer lines overall with cleaner intent.

**References:** [§26400059438](https://github.com/jonaskay/rocket/actions/runs/26400059438)




> Generated by [Test Cleanup Agent](https://github.com/jonaskay/rocket/actions/runs/26400059438)
> - [x] expires <!-- gh-aw-expires: 2026-05-27T12:29:06.674Z --> on May 27, 2026, 12:29 PM UTC

<!-- gh-aw-agentic-workflow: Test Cleanup Agent, engine: copilot, id: 26400059438, workflow_id: test-cleanup-agent, run: https://github.com/jonaskay/rocket/actions/runs/26400059438 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: test-cleanup-agent -->