### PR TITLE
[docs] Update glossary - daily scan

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -22,6 +22,8 @@ Important domain terms for the Rocket training platform.
 
 **Master Training** — A reusable training template created and owned by a trainer. Contains slides, prerequisite assets, and exercises. Multiple training sessions can be generated from a single master training at different points in time.
 
+**Master Trainings Dashboard** — The primary landing page for trainers at `/master_trainings`. Displays all master trainings belonging to the trainer's account in a table ordered by most recently updated. Each row shows the training's title, a truncated description, created and updated timestamps, and an Edit link. Trainers are automatically redirected here upon sign-in. Only trainers can access this page; account admins are redirected away with an authorization error.
+
 **Password Gate** — The password entry page shown at `/s/:slug/unlock` when a training session is password-protected. Participants must submit the correct password before the session content is revealed.
 
 **Prerequisite Asset** — A file of any type (PDF, video, ZIP, etc.) attached to a master training that participants are expected to review or download before the training session begins.


### PR DESCRIPTION
## Glossary Updates - 2026-05-27

### Scan Type
- [x] Incremental (daily - last 24 hours)
- [ ] Full scan (weekly - last 7 days)

### Terms Added
- **Master Trainings Dashboard**: Term was present in multiple documentation files and referenced in PR #117 but was missing from the glossary. The cache from a previous run had tracked it as "added" but it was never written to the file.

### Terms Updated
_(none)_

### Changes Analyzed
- Reviewed commits since last cache run (2026-05-21)
- Analyzed merged PR #117 (Add edit and update actions for master trainings)
- Checked `docs/issues/62/demo.md`, `docs/issues/116/demo.md`, `docs/feature_list.json`, and `docs/app_spec.txt` for term usage

### Related Changes
- Commit `879d3e8`: Add edit and update actions for master trainings
- PR #117: Adds Edit link to Master Trainings Dashboard rows — explicitly references the dashboard in demo docs

### Notes
- No commits in the last 24 hours (most recent: 2026-05-25)
- The "Master Trainings Dashboard" term appears consistently across multiple documentation files as the primary trainer landing page at `/master_trainings`
- Cache has been updated to reflect this run and processed commits




> Generated by [Glossary Maintainer](https://github.com/jonaskay/rocket/actions/runs/26512061004)
> - [x] expires <!-- gh-aw-expires: 2026-05-29T12:59:52.797Z --> on May 29, 2026, 12:59 PM UTC

<!-- gh-aw-agentic-workflow: Glossary Maintainer, engine: copilot, id: 26512061004, workflow_id: glossary-maintainer, run: https://github.com/jonaskay/rocket/actions/runs/26512061004 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: glossary-maintainer -->