### PR TITLE
[test] Extract shared helpers to reduce test duplication

### DIFF
--- a/test/integration/account_trainers_test.rb
+++ b/test/integration/account_trainers_test.rb
@@ -47,44 +47,17 @@ class AccountTrainersIntegrationTest < ActionDispatch::IntegrationTest
 
   test "admin removes an active trainer" do
     sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_one)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_removed(users(:acme_trainer_one))
   end
 
   test "admin removes an inactive trainer" do
     sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_two)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_removed(users(:acme_trainer_two))
   end
 
   test "admin removes a pending trainer" do
     sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_three)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_removed(users(:acme_trainer_three))
   end
 
   test "admin fails to remove a trainer when destroy fails" do
@@ -126,5 +99,17 @@ class AccountTrainersIntegrationTest < ActionDispatch::IntegrationTest
 
     assert_response :not_found
     assert_equal original_attributes, other_trainer.reload.attributes
+  end
+
+  private
+
+  def assert_trainer_removed(trainer)
+    assert_difference "User.count", -1 do
+      delete account_trainer_path(trainer)
+    end
+    assert_redirected_to account_trainers_path
+    follow_redirect!
+    assert_match trainer.email_address, flash[:notice]
+    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
   end
 end

--- a/test/integration/forced_password_change_test.rb
+++ b/test/integration/forced_password_change_test.rb
@@ -1,25 +1,24 @@
 require "test_helper"
 
 class ForcedPasswordChangeTest < ActionDispatch::IntegrationTest
-  test "pending user is redirected to change-password page after login" do
-    user = users(:acme_trainer_three)
+  setup do
+    @pending_user = users(:acme_trainer_three)
+  end
 
-    post session_path, params: { email_address: user.email_address, password: "password" }
+  test "pending user is redirected to change-password page after login" do
+    post session_path, params: { email_address: @pending_user.email_address, password: "password" }
 
     assert_redirected_to edit_account_password_path
   end
 
   test "pending user login creates a session" do
-    user = users(:acme_trainer_three)
-
     assert_difference "Session.count" do
-      post session_path, params: { email_address: user.email_address, password: "password" }
+      post session_path, params: { email_address: @pending_user.email_address, password: "password" }
     end
   end
 
   test "pending user cannot navigate to other pages" do
-    user = users(:acme_trainer_three)
-    sign_in_as(user)
+    sign_in_as(@pending_user)
 
     get root_path
 
@@ -27,8 +26,7 @@ class ForcedPasswordChangeTest < ActionDispatch::IntegrationTest
   end
 
   test "pending user cannot navigate to account settings" do
-    user = users(:acme_trainer_three)
-    sign_in_as(user)
+    sign_in_as(@pending_user)
 
     get edit_account_settings_path
 
@@ -36,8 +34,7 @@ class ForcedPasswordChangeTest < ActionDispatch::IntegrationTest
   end
 
   test "pending user can access the change-password page" do
-    user = users(:acme_trainer_three)
-    sign_in_as(user)
+    sign_in_as(@pending_user)
 
     get edit_account_password_path
 
@@ -45,28 +42,26 @@ class ForcedPasswordChangeTest < ActionDispatch::IntegrationTest
   end
 
   test "submitting a valid password changes status to active and redirects to home" do
-    user = users(:acme_trainer_three)
-    sign_in_as(user)
+    sign_in_as(@pending_user)
 
     patch account_password_path, params: { user: { password: "newpassword123!", password_confirmation: "newpassword123!" } }
 
     assert_redirected_to master_trainings_path
     assert_equal I18n.t("account.passwords.update.success"), flash[:notice]
 
-    user.reload
-    assert user.active?
+    @pending_user.reload
+    assert @pending_user.active?
   end
 
   test "submitting mismatched passwords re-renders the form with errors" do
-    user = users(:acme_trainer_three)
-    sign_in_as(user)
+    sign_in_as(@pending_user)
 
     patch account_password_path, params: { user: { password: "newpassword123!", password_confirmation: "different!" } }
 
     assert_response :unprocessable_entity
 
-    user.reload
-    assert user.pending_password_change?
+    @pending_user.reload
+    assert @pending_user.pending_password_change?
   end
 
   test "active user is not redirected to change-password page" do

--- a/test/integration/master_trainings_test.rb
+++ b/test/integration/master_trainings_test.rb
@@ -39,65 +39,35 @@ class MasterTrainingsIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "super admin cannot access the master trainings dashboard" do
-    sign_in_as(users(:one))
-
-    get master_trainings_path
-
-    assert_redirected_to root_path
-    assert_equal I18n.t("master_trainings.unauthorized"), flash[:alert]
+    assert_unauthorized_master_training_access(users(:one)) { get master_trainings_path }
   end
 
   test "super admin cannot access the edit action" do
     training = master_trainings(:acme_training_one)
-    sign_in_as(users(:one))
-
-    get edit_master_training_path(training)
-
-    assert_redirected_to root_path
-    assert_equal I18n.t("master_trainings.unauthorized"), flash[:alert]
+    assert_unauthorized_master_training_access(users(:one)) { get edit_master_training_path(training) }
   end
 
   test "super admin cannot access the update action" do
     training = master_trainings(:acme_training_one)
-    sign_in_as(users(:one))
-
-    patch master_training_path(training), params: {
-      master_training: { title: "Hijacked", description: "" }
-    }
-
-    assert_redirected_to root_path
-    assert_equal I18n.t("master_trainings.unauthorized"), flash[:alert]
+    assert_unauthorized_master_training_access(users(:one)) do
+      patch master_training_path(training), params: { master_training: { title: "Hijacked", description: "" } }
+    end
   end
 
   test "client admin cannot access the master trainings dashboard" do
-    sign_in_as(users(:acme_admin))
-
-    get master_trainings_path
-
-    assert_redirected_to root_path
-    assert_equal I18n.t("master_trainings.unauthorized"), flash[:alert]
+    assert_unauthorized_master_training_access(users(:acme_admin)) { get master_trainings_path }
   end
 
   test "client admin cannot access the edit action" do
     training = master_trainings(:acme_training_one)
-    sign_in_as(users(:acme_admin))
-
-    get edit_master_training_path(training)
-
-    assert_redirected_to root_path
-    assert_equal I18n.t("master_trainings.unauthorized"), flash[:alert]
+    assert_unauthorized_master_training_access(users(:acme_admin)) { get edit_master_training_path(training) }
   end
 
   test "client admin cannot access the update action" do
     training = master_trainings(:acme_training_one)
-    sign_in_as(users(:acme_admin))
-
-    patch master_training_path(training), params: {
-      master_training: { title: "Hijacked", description: "" }
-    }
-
-    assert_redirected_to root_path
-    assert_equal I18n.t("master_trainings.unauthorized"), flash[:alert]
+    assert_unauthorized_master_training_access(users(:acme_admin)) do
+      patch master_training_path(training), params: { master_training: { title: "Hijacked", description: "" } }
+    end
   end
 
   test "unauthenticated user is redirected to sign in" do
@@ -201,5 +171,14 @@ class MasterTrainingsIntegrationTest < ActionDispatch::IntegrationTest
     }
 
     assert_response :not_found
+  end
+
+  private
+
+  def assert_unauthorized_master_training_access(user)
+    sign_in_as(user)
+    yield
+    assert_redirected_to root_path
+    assert_equal I18n.t("master_trainings.unauthorized"), flash[:alert]
   end
 end

--- a/test/system/account_trainers_test.rb
+++ b/test/system/account_trainers_test.rb
@@ -1,14 +1,14 @@
 require "application_system_test_case"
 
 class AccountTrainersTest < ApplicationSystemTestCase
-  test "account admin sees trainers listed with their status" do
-    account_admin = users(:acme_admin)
-
-    sign_in_via_ui account_admin
+  setup do
+    @account_admin = users(:acme_admin)
+    sign_in_via_ui @account_admin
     assert_current_path edit_account_settings_path
-
     click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+  end
 
+  test "account admin sees trainers listed with their status" do
     assert_text users(:acme_trainer_one).email_address
     assert_text users(:acme_trainer_two).email_address
     assert_text users(:acme_trainer_three).email_address
@@ -19,13 +19,7 @@ class AccountTrainersTest < ApplicationSystemTestCase
   end
 
   test "admin removes a trainer from the roster" do
-    account_admin = users(:acme_admin)
     trainer = users(:acme_trainer_one)
-
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
 
     assert_text trainer.email_address
     within("tr", text: trainer.email_address) do
@@ -39,13 +33,7 @@ class AccountTrainersTest < ApplicationSystemTestCase
   end
 
   test "admin deactivates an active trainer and reactivates them" do
-    account_admin = users(:acme_admin)
     trainer = users(:acme_trainer_one)
-
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
 
     assert_text trainer.email_address
     within("tr", text: trainer.email_address) do


### PR DESCRIPTION
Reduces test duplication by extracting 4 shared helpers across integration and system tests. Net result: **53 lines removed**, 0 behavior changes.

### Helpers Extracted

| Helper | Location | Occurrences Replaced |
|--------|----------|----------------------|
| `assert_unauthorized_master_training_access(user)` | `MasterTrainingsIntegrationTest` (private) | 6 |
| `assert_trainer_removed(trainer)` | `AccountTrainersIntegrationTest` (private) | 3 |
| `setup` block with `@pending_user` | `ForcedPasswordChangeTest` | 7 |
| `setup` block (sign-in + navigate to roster) | `AccountTrainersTest` (system) | 3 |

### Before / After

#### `assert_unauthorized_master_training_access` — replaces 6 copy-pasted blocks in `master_trainings_test.rb`

```ruby
# Before (repeated 6× with only the user and request varying)
sign_in_as(users(:one))
get master_trainings_path
assert_redirected_to root_path
assert_equal I18n.t("master_trainings.unauthorized"), flash[:alert]

# After
test "super admin cannot access the master trainings dashboard" do
  assert_unauthorized_master_training_access(users(:one)) { get master_trainings_path }
end
```

#### `assert_trainer_removed` — replaces 3 copy-pasted blocks in `account_trainers_test.rb`

```ruby
# Before (repeated 3× with only the trainer fixture varying)
assert_difference "User.count", -1 do
  delete account_trainer_path(trainer)
end
assert_redirected_to account_trainers_path
follow_redirect!
assert_match trainer.email_address, flash[:notice]
assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }

# After
test "admin removes an active trainer" do
  sign_in_as(`@account_admin`)
  assert_trainer_removed(users(:acme_trainer_one))
end
```

#### `setup` block in `ForcedPasswordChangeTest` — removes 7 repeated fixture assignments

```ruby
# Before (in 7 tests)
user = users(:acme_trainer_three)

# After (once, in setup)
setup do
  `@pending_user` = users(:acme_trainer_three)
end
```

#### `setup` block in `AccountTrainersTest` (system) — removes 4-line navigation sequence repeated in all 3 tests

```ruby
# Before (in each of 3 tests)
account_admin = users(:acme_admin)
sign_in_via_ui account_admin
assert_current_path edit_account_settings_path
click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")

# After (once, in setup)
setup do
  `@account_admin` = users(:acme_admin)
  sign_in_via_ui `@account_admin`
  assert_current_path edit_account_settings_path
  click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
end
```

### Files Changed
- `test/integration/master_trainings_test.rb` — 6 occurrences replaced, helper added
- `test/integration/account_trainers_test.rb` — 3 occurrences replaced, helper added
- `test/integration/forced_password_change_test.rb` — 7 fixture assignments replaced with `@pending_user`
- `test/system/account_trainers_test.rb` — 3 navigation sequences replaced with `setup` block

**References:** [§27139048678](https://github.com/jonaskay/rocket/actions/runs/27139048678)




> Generated by [Test Cleanup Agent](https://github.com/jonaskay/rocket/actions/runs/27139048678)
> - [x] expires <!-- gh-aw-expires: 2026-06-10T13:05:15.115Z --> on Jun 10, 2026, 1:05 PM UTC

<!-- gh-aw-agentic-workflow: Test Cleanup Agent, engine: copilot, id: 27139048678, workflow_id: test-cleanup-agent, run: https://github.com/jonaskay/rocket/actions/runs/27139048678 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: test-cleanup-agent -->