### PR TITLE
[test] Extract shared helpers to reduce test duplication

### DIFF
--- a/test/integration/account_trainers_test.rb
+++ b/test/integration/account_trainers_test.rb
@@ -47,44 +47,17 @@ class AccountTrainersIntegrationTest < ActionDispatch::IntegrationTest
 
   test "admin removes an active trainer" do
     sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_one)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_removed_successfully(users(:acme_trainer_one))
   end
 
   test "admin removes an inactive trainer" do
     sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_two)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_removed_successfully(users(:acme_trainer_two))
   end
 
   test "admin removes a pending trainer" do
     sign_in_as(@account_admin)
-    trainer = users(:acme_trainer_three)
-
-    assert_difference "User.count", -1 do
-      delete account_trainer_path(trainer)
-    end
-
-    assert_redirected_to account_trainers_path
-    follow_redirect!
-    assert_match trainer.email_address, flash[:notice]
-    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
+    assert_trainer_removed_successfully(users(:acme_trainer_three))
   end
 
   test "admin fails to remove a trainer when destroy fails" do
@@ -126,5 +99,18 @@ class AccountTrainersIntegrationTest < ActionDispatch::IntegrationTest
 
     assert_response :not_found
     assert_equal original_attributes, other_trainer.reload.attributes
+  end
+
+  private
+
+  def assert_trainer_removed_successfully(trainer)
+    assert_difference "User.count", -1 do
+      delete account_trainer_path(trainer)
+    end
+
+    assert_redirected_to account_trainers_path
+    follow_redirect!
+    assert_match trainer.email_address, flash[:notice]
+    assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }
   end
 end

--- a/test/integration/master_trainings_test.rb
+++ b/test/integration/master_trainings_test.rb
@@ -40,64 +40,46 @@ class MasterTrainingsIntegrationTest < ActionDispatch::IntegrationTest
 
   test "super admin cannot access the master trainings dashboard" do
     sign_in_as(users(:one))
-
     get master_trainings_path
-
-    assert_redirected_to root_path
-    assert_equal I18n.t("master_trainings.unauthorized"), flash[:alert]
+    assert_master_training_unauthorized
   end
 
   test "super admin cannot access the edit action" do
     training = master_trainings(:acme_training_one)
     sign_in_as(users(:one))
-
     get edit_master_training_path(training)
-
-    assert_redirected_to root_path
-    assert_equal I18n.t("master_trainings.unauthorized"), flash[:alert]
+    assert_master_training_unauthorized
   end
 
   test "super admin cannot access the update action" do
     training = master_trainings(:acme_training_one)
     sign_in_as(users(:one))
-
     patch master_training_path(training), params: {
       master_training: { title: "Hijacked", description: "" }
     }
-
-    assert_redirected_to root_path
-    assert_equal I18n.t("master_trainings.unauthorized"), flash[:alert]
+    assert_master_training_unauthorized
   end
 
   test "client admin cannot access the master trainings dashboard" do
     sign_in_as(users(:acme_admin))
-
     get master_trainings_path
-
-    assert_redirected_to root_path
-    assert_equal I18n.t("master_trainings.unauthorized"), flash[:alert]
+    assert_master_training_unauthorized
   end
 
   test "client admin cannot access the edit action" do
     training = master_trainings(:acme_training_one)
     sign_in_as(users(:acme_admin))
-
     get edit_master_training_path(training)
-
-    assert_redirected_to root_path
-    assert_equal I18n.t("master_trainings.unauthorized"), flash[:alert]
+    assert_master_training_unauthorized
   end
 
   test "client admin cannot access the update action" do
     training = master_trainings(:acme_training_one)
     sign_in_as(users(:acme_admin))
-
     patch master_training_path(training), params: {
       master_training: { title: "Hijacked", description: "" }
     }
-
-    assert_redirected_to root_path
-    assert_equal I18n.t("master_trainings.unauthorized"), flash[:alert]
+    assert_master_training_unauthorized
   end
 
   test "unauthenticated user is redirected to sign in" do
@@ -201,5 +183,12 @@ class MasterTrainingsIntegrationTest < ActionDispatch::IntegrationTest
     }
 
     assert_response :not_found
+  end
+
+  private
+
+  def assert_master_training_unauthorized
+    assert_redirected_to root_path
+    assert_equal I18n.t("master_trainings.unauthorized"), flash[:alert]
   end
 end

--- a/test/system/account_trainers_test.rb
+++ b/test/system/account_trainers_test.rb
@@ -2,12 +2,7 @@ require "application_system_test_case"
 
 class AccountTrainersTest < ApplicationSystemTestCase
   test "account admin sees trainers listed with their status" do
-    account_admin = users(:acme_admin)
-
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+    sign_in_and_visit_trainer_roster(users(:acme_admin))
 
     assert_text users(:acme_trainer_one).email_address
     assert_text users(:acme_trainer_two).email_address
@@ -19,13 +14,9 @@ class AccountTrainersTest < ApplicationSystemTestCase
   end
 
   test "admin removes a trainer from the roster" do
-    account_admin = users(:acme_admin)
     trainer = users(:acme_trainer_one)
 
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+    sign_in_and_visit_trainer_roster(users(:acme_admin))
 
     assert_text trainer.email_address
     within("tr", text: trainer.email_address) do
@@ -39,13 +30,9 @@ class AccountTrainersTest < ApplicationSystemTestCase
   end
 
   test "admin deactivates an active trainer and reactivates them" do
-    account_admin = users(:acme_admin)
     trainer = users(:acme_trainer_one)
 
-    sign_in_via_ui account_admin
-    assert_current_path edit_account_settings_path
-
-    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
+    sign_in_and_visit_trainer_roster(users(:acme_admin))
 
     assert_text trainer.email_address
     within("tr", text: trainer.email_address) do
@@ -67,5 +54,13 @@ class AccountTrainersTest < ApplicationSystemTestCase
     within("tr", text: trainer.email_address) do
       assert_text "Active"
     end
+  end
+
+  private
+
+  def sign_in_and_visit_trainer_roster(account_admin)
+    sign_in_via_ui account_admin
+    assert_current_path edit_account_settings_path
+    click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")
   end
 end


### PR DESCRIPTION
Extracts three private helper methods from repeated test code patterns, removing 30 lines of duplicated logic across integration and system tests.

### Helpers Extracted

- **`MasterTrainingsIntegrationTest#assert_master_training_unauthorized`** — replaces 6 identical 2-line assertion pairs (`assert_redirected_to root_path` + `assert_equal I18n.t("master_trainings.unauthorized"), flash[:alert]`)
- **`AccountTrainersIntegrationTest#assert_trainer_removed_successfully`** — replaces 3 identical 10-line blocks that delete a trainer, follow the redirect, and assert the expected flash/record state
- **`AccountTrainersTest#sign_in_and_visit_trainer_roster`** (system) — replaces 3 identical 3-line sequences that sign in an account admin and navigate to the Trainer Roster page

### Before / After

```ruby
# Before — repeated verbatim 6 times in master_trainings_test.rb
assert_redirected_to root_path
assert_equal I18n.t("master_trainings.unauthorized"), flash[:alert]

# After
assert_master_training_unauthorized
```

```ruby
# Before — repeated verbatim 3 times in account_trainers_test.rb
trainer = users(:acme_trainer_one)
assert_difference "User.count", -1 do
  delete account_trainer_path(trainer)
end
assert_redirected_to account_trainers_path
follow_redirect!
assert_match trainer.email_address, flash[:notice]
assert_raises(ActiveRecord::RecordNotFound) { trainer.reload }

# After
assert_trainer_removed_successfully(users(:acme_trainer_one))
```

```ruby
# Before — repeated verbatim 3 times in system/account_trainers_test.rb
account_admin = users(:acme_admin)
sign_in_via_ui account_admin
assert_current_path edit_account_settings_path
click_link_and_confirm "Trainer Roster", title: I18n.t("account.trainers.index.title")

# After
sign_in_and_visit_trainer_roster(users(:acme_admin))
```

### Files Changed

- `test/integration/master_trainings_test.rb` — 6 occurrences replaced, private helper added
- `test/integration/account_trainers_test.rb` — 3 occurrences replaced, private helper added
- `test/system/account_trainers_test.rb` — 3 occurrences replaced, private helper added




> Generated by [Test Cleanup Agent](https://github.com/jonaskay/rocket/actions/runs/27554902849)
> - [x] expires <!-- gh-aw-expires: 2026-06-17T15:02:48.656Z --> on Jun 17, 2026, 3:02 PM UTC

<!-- gh-aw-agentic-workflow: Test Cleanup Agent, engine: copilot, id: 27554902849, workflow_id: test-cleanup-agent, run: https://github.com/jonaskay/rocket/actions/runs/27554902849 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: test-cleanup-agent -->